### PR TITLE
Add a guard to prevent stuck state on cookie check

### DIFF
--- a/src/pages/VideoCall/permissions/CookiePermission.js
+++ b/src/pages/VideoCall/permissions/CookiePermission.js
@@ -1,6 +1,10 @@
 import React, { useEffect } from 'react'
 import Check from './Check'
-import { STATE_DENIED, STATE_GRANTED } from './PermissionConstants'
+import {
+    STATE_DENIED,
+    STATE_GRANTED,
+    STATE_WAITING,
+} from './PermissionConstants'
 import useCookiePermission from '../../../hooks/useCookiePermission'
 import { Button } from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
@@ -15,6 +19,18 @@ const CookiePermission = ({ onGranted }) => {
             onGranted()
         }
     }, [permissionResult, onGranted])
+
+    useEffect(() => {
+        let timer = setTimeout(() => {
+            if (permissionResult === STATE_WAITING) {
+                onCookieRenewClick()
+            }
+        }, 10000)
+
+        return () => {
+            clearTimeout(timer)
+        }
+    }, [permissionResult])
 
     const onCookieRenewClick = () => {
         if (hasCookiebot()) {

--- a/src/pages/VideoCall/permissions/CookiePermission.js
+++ b/src/pages/VideoCall/permissions/CookiePermission.js
@@ -21,7 +21,7 @@ const CookiePermission = ({ onGranted }) => {
     }, [permissionResult, onGranted])
 
     useEffect(() => {
-        let timer = setTimeout(() => {
+        const timer = setTimeout(() => {
             if (permissionResult === STATE_WAITING) {
                 onCookieRenewClick()
             }

--- a/src/pages/VideoCall/permissions/CookiePermission.js
+++ b/src/pages/VideoCall/permissions/CookiePermission.js
@@ -25,7 +25,7 @@ const CookiePermission = ({ onGranted }) => {
             if (permissionResult === STATE_WAITING) {
                 onCookieRenewClick()
             }
-        }, 10000)
+        }, 5000)
 
         return () => {
             clearTimeout(timer)


### PR DESCRIPTION
It happenned that the cookie check stayed in waiting without nothing happening, this should prevent that but is more a guard than a real bug fix due to the impossibility to test this localy. 

This has already been deployed in production (not in dev)
