### PR TITLE
Replace npm install by npm ci to speed up CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: npm install, build
       run: |
-        npm install
+        npm ci
         npm run build
     - name: move to function, init & run test
       run: |
         cd functions
-        npm install
+        npm ci
         npm run build


### PR DESCRIPTION
npm ci shold be the safest wai to build a project on any CI, offer greater npm install speed and only use version from package-lock.json
