### PR TITLE
Fix FormError due to CallError translations

### DIFF
--- a/src/components/Form/CallError.tsx
+++ b/src/components/Form/CallError.tsx
@@ -1,13 +1,9 @@
-import { useTranslation } from 'react-i18next'
-
 export interface Error {
     code: string
     message: string
 }
 
-const CallError = (error: Error) => {
-    const { t } = useTranslation('form')
-
+const CallError = (error: Error, t: any) => {
     const e = error
     if (e && e.code) {
         switch (e.code) {

--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -174,7 +174,7 @@ export default function Form({ onSubmit, error }: FormProps) {
                                 </Button>
                             </FormSubmit>
                             {error && (
-                                <SubmitError>{CallError(error)}</SubmitError>
+                                <SubmitError>{CallError(error, t)}</SubmitError>
                             )}
                         </BootstrapForm>
                     )

--- a/src/components/FormMobile/index.tsx
+++ b/src/components/FormMobile/index.tsx
@@ -146,7 +146,7 @@ export default function FormMobile({ onSubmit, error }) {
                                 </Button>
                             </FormSubmit>
                             {error && (
-                                <SubmitError>{CallError(error)}</SubmitError>
+                                <SubmitError>{CallError(error, t)}</SubmitError>
                             )}
                         </BootstrapForm>
                     )


### PR DESCRIPTION
I found an error in "moving to typescript" PR affecting `Form` & `FormMobile` components.