### PR TITLE
Replace create with join room

### DIFF
--- a/functions/src/api/auth/assertValidToken.spec.ts
+++ b/functions/src/api/auth/assertValidToken.spec.ts
@@ -1,7 +1,7 @@
 // tslint:disable-next-line
 import '../../testUtils/mockFirebaseAdminAndFunctions'
 import { firestoreGet } from '../../testUtils/firestoreStub'
-import { JWTData } from '../../../../types/JWT'
+import { JWTData } from '../../types/JWT'
 import { assertValidToken } from './assertValidToken'
 import { ForbiddenError } from '../errors/HttpError'
 

--- a/functions/src/api/auth/assertValidToken.ts
+++ b/functions/src/api/auth/assertValidToken.ts
@@ -1,4 +1,4 @@
-import { JWTData, JWTToken } from '../../../../types/JWT'
+import { JWTData, JWTToken } from '../../types/JWT'
 import { isTokenValidInDb } from '../../db/isTokenValidInDb'
 import { ForbiddenError } from '../errors/HttpError'
 

--- a/functions/src/api/middlewares/authenticateJWTMiddleware.ts
+++ b/functions/src/api/middlewares/authenticateJWTMiddleware.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express'
 import * as jsonWebToken from 'jsonwebtoken'
 import { getJWTEnv } from '../../firebase/env'
-import { JWTData, JWTToken } from '../../../../types/JWT'
+import { JWTData, JWTToken } from '../../types/JWT'
 import {
     ForbiddenError,
     PreconditionFailedError,

--- a/functions/src/api/v1/invite/inviteParticipants.ts
+++ b/functions/src/api/v1/invite/inviteParticipants.ts
@@ -6,7 +6,7 @@ import { InvitationDestination } from '../../../types/InvitationDestination'
 import { getAppEnv } from '../../../firebase/env'
 import { NotificationContent } from '../../../types/Notification'
 import { sendNotifications } from '../../../notifications/sendNotifications'
-import { UID } from '../../../../../types/uid'
+import { UID } from '../../../types/uid'
 
 /**
  * @swagger

--- a/functions/src/api/v1/rooms/createRoom.ts
+++ b/functions/src/api/v1/rooms/createRoom.ts
@@ -2,12 +2,12 @@ import { Request, Response } from 'express'
 import { addRoom } from '../../../db/addRoom'
 import { createTwilioRoom } from './service/createTwilioRoom'
 import { updateRoom } from '../../../db/updateRoom'
-import { NewRoomResponse } from '../../../../../types/NewRoomResponse'
+import { NewRoomResponse } from '../../../types/NewRoomResponse'
 import { wrap } from 'async-middleware'
-import { UID } from '../../../../../types/uid'
+import { UID } from '../../../types/uid'
 import { setRoom } from '../../../db/setRoom'
 import { assertNewRoomCreationGranted } from '../subscription/assertNewRoomCreationGranted'
-import { RoomId } from '../../../../../types/Room'
+import { RoomId } from '../../../types/Room'
 
 /**
  * @swagger

--- a/functions/src/api/v1/rooms/joinRoom.ts
+++ b/functions/src/api/v1/rooms/joinRoom.ts
@@ -7,8 +7,8 @@ import {
     TTL_ACCESS_TOKEN_PARTICIPANT_SECONDS,
 } from './service/createTwilioClientToken'
 import { createRoom } from './createRoom'
-import { UID } from '../../../../../types/uid'
-import { Room, RoomId } from '../../../../../types/Room'
+import { UID } from '../../../types/uid'
+import { Room, RoomId } from '../../../types/Room'
 
 /**
  * @swagger

--- a/functions/src/api/v1/rooms/service/createTwilioClientToken.ts
+++ b/functions/src/api/v1/rooms/service/createTwilioClientToken.ts
@@ -1,5 +1,5 @@
-import { RoomId } from '../../../../../../types/Room'
-import { UID } from '../../../../../../types/uid'
+import { RoomId } from '../../../../types/Room'
+import { UID } from '../../../../types/uid'
 import * as AccessToken from 'twilio/lib/jwt/AccessToken'
 import { getTwilioEnv } from '../../../../firebase/env'
 

--- a/functions/src/api/v1/rooms/service/createTwilioRoom.ts
+++ b/functions/src/api/v1/rooms/service/createTwilioRoom.ts
@@ -1,5 +1,5 @@
 import { twilioClient } from './twilioClient'
-import { RoomId } from '../../../../../../types/Room'
+import { RoomId } from '../../../../types/Room'
 
 export const createTwilioRoom = async (roomId: RoomId) => {
     const room = await twilioClient.video.rooms.create({

--- a/functions/src/api/v1/subscription/assertNewRoomCreationGranted.ts
+++ b/functions/src/api/v1/subscription/assertNewRoomCreationGranted.ts
@@ -1,4 +1,4 @@
-import { UID } from '../../../../../types/uid'
+import { UID } from '../../../types/uid'
 import { getUser } from '../../../db/getUser'
 import { PaymentRequiredError } from '../../errors/HttpError'
 

--- a/functions/src/db/addRoom.ts
+++ b/functions/src/db/addRoom.ts
@@ -1,7 +1,7 @@
 import { COLLECTION_ROOMS, DEFAULT_ROOM_TYPE } from './constants'
-import { RoomId } from '../../../types/Room'
+import { RoomId } from '../types/Room'
 import { db, serverTimestamp } from '../firebase/firebase'
-import { UID } from '../../../types/uid'
+import { UID } from '../types/uid'
 
 export const addRoom = async (
     userId: UID,

--- a/functions/src/db/addTokenToUser.ts
+++ b/functions/src/db/addTokenToUser.ts
@@ -1,6 +1,6 @@
-import { UID } from '../../../types/uid'
+import { UID } from '../types/uid'
 import { db, serverTimestamp } from '../firebase/firebase'
-import { JWTToken } from '../../../types/JWT'
+import { JWTToken } from '../types/JWT'
 
 export const addTokenToUser = async (
     userId: UID,

--- a/functions/src/db/assertRightsToEditRoom.ts
+++ b/functions/src/db/assertRightsToEditRoom.ts
@@ -1,5 +1,5 @@
-import { RoomId, Room } from '../../../types/Room'
-import { UID } from '../../../types/uid'
+import { RoomId, Room } from '../types/Room'
+import { UID } from '../types/uid'
 import { ForbiddenError } from '../api/errors/HttpError'
 import { getRoom } from './getRoom'
 

--- a/functions/src/db/doesRoomExist.ts
+++ b/functions/src/db/doesRoomExist.ts
@@ -1,5 +1,5 @@
 import { COLLECTION_ROOMS } from './constants'
-import { RoomId } from '../../../types/Room'
+import { RoomId } from '../types/Room'
 import { db } from '../firebase/firebase'
 
 export const doesRoomExist = async (roomId: RoomId): Promise<boolean> => {

--- a/functions/src/db/getRoom.ts
+++ b/functions/src/db/getRoom.ts
@@ -1,5 +1,5 @@
 import { COLLECTION_ROOMS } from './constants'
-import { Room, RoomId } from '../../../types/Room'
+import { Room, RoomId } from '../types/Room'
 import { db } from '../firebase/firebase'
 import { RoomNotFoundError } from '../api/errors/HttpError'
 

--- a/functions/src/db/getRooms.ts
+++ b/functions/src/db/getRooms.ts
@@ -1,6 +1,6 @@
 import { COLLECTION_ROOMS } from './constants'
-import { UID } from '../../../types/uid'
-import { Room } from '../../../types/Room'
+import { UID } from '../types/uid'
+import { Room } from '../types/Room'
 import { db } from '../firebase/firebase'
 
 type Response = Pick<Room, 'id' | 'createdAt' | 'updatedAt'>

--- a/functions/src/db/getUser.ts
+++ b/functions/src/db/getUser.ts
@@ -1,4 +1,4 @@
-import { UID } from '../../../types/uid'
+import { UID } from '../types/uid'
 import { db } from '../firebase/firebase'
 import { NotFoundError } from '../api/errors/HttpError'
 import { UserData } from '../types/UserData'

--- a/functions/src/db/getUserToken.ts
+++ b/functions/src/db/getUserToken.ts
@@ -1,7 +1,7 @@
-import { BadRequestError } from '../api/errors/HttpError'
 import { getUser } from './getUser'
-import { UID } from '../../../types/uid'
-import { JWTToken } from '../../../types/JWT'
+import { JWTToken } from '../types/JWT'
+import { UID } from '../types/uid'
+import { BadRequestError } from '../api/errors/HttpError'
 
 export const getUserToken = async (userId: UID): Promise<JWTToken | null> => {
     const userData = await getUser(userId)

--- a/functions/src/db/isTokenValidInDb.spec.ts
+++ b/functions/src/db/isTokenValidInDb.spec.ts
@@ -1,6 +1,6 @@
 // tslint:disable-next-line
 import '../testUtils/mockFirebaseAdminAndFunctions'
-import { JWTData } from '../../../types/JWT'
+import { JWTData } from '../types/JWT'
 import { firestoreGet } from '../testUtils/firestoreStub'
 import { isTokenValidInDb } from './isTokenValidInDb'
 

--- a/functions/src/db/isTokenValidInDb.ts
+++ b/functions/src/db/isTokenValidInDb.ts
@@ -1,6 +1,6 @@
 import { db } from '../firebase/firebase'
 import { UserData } from '../types/UserData'
-import { JWTData, JWTToken } from '../../../types/JWT'
+import { JWTData, JWTToken } from '../types/JWT'
 
 export const isTokenValidInDb = async (
     jwtData: JWTData,

--- a/functions/src/db/setRoom.ts
+++ b/functions/src/db/setRoom.ts
@@ -1,7 +1,7 @@
 import { COLLECTION_ROOMS, DEFAULT_ROOM_TYPE } from './constants'
-import { RoomId } from '../../../types/Room'
+import { RoomId } from '../types/Room'
 import { db, serverTimestamp } from '../firebase/firebase'
-import { UID } from '../../../types/uid'
+import { UID } from '../types/uid'
 
 export const setRoom = async (
     userId: UID,

--- a/functions/src/db/updateRoom.ts
+++ b/functions/src/db/updateRoom.ts
@@ -1,7 +1,7 @@
 import { COLLECTION_ROOMS } from './constants'
-import { RoomId, RoomSid } from '../../../types/Room'
+import { RoomId, RoomSid } from '../types/Room'
 import { db, serverTimestamp } from '../firebase/firebase'
-import { UID } from '../../../types/uid'
+import { UID } from '../types/uid'
 
 export interface RoomEditData {
     roomId: RoomId

--- a/functions/src/firebase/env.ts
+++ b/functions/src/firebase/env.ts
@@ -1,5 +1,5 @@
 import * as functions from 'firebase-functions'
-import { JWTKey } from '../../../types/JWT'
+import { JWTKey } from '../types/JWT'
 import { InternalServerError } from '../api/errors/HttpError'
 import { TwilioEnv } from '../types/TwilioEnv'
 import { AppEnv } from '../types/AppEnv'

--- a/functions/src/types/JWT.ts
+++ b/functions/src/types/JWT.ts
@@ -1,0 +1,9 @@
+import { UID } from './uid'
+
+export interface JWTData {
+    uid: UID
+    iat: number
+}
+
+export type JWTKey = string
+export type JWTToken = string

--- a/functions/src/types/JoinRoomResponse.ts
+++ b/functions/src/types/JoinRoomResponse.ts
@@ -1,0 +1,4 @@
+export interface JoinRoomResponse {
+    jwtAccessToken: string
+    ttl: number
+}

--- a/functions/src/types/NewRoomResponse.ts
+++ b/functions/src/types/NewRoomResponse.ts
@@ -1,0 +1,6 @@
+import { RoomId, RoomSid } from './Room'
+
+export interface NewRoomResponse {
+    roomId: RoomId
+    roomSid: RoomSid
+}

--- a/functions/src/types/Room.ts
+++ b/functions/src/types/Room.ts
@@ -1,0 +1,14 @@
+import { UID } from './uid'
+
+export type RoomId = string
+export type RoomSid = string
+
+export interface Room {
+    id: RoomId
+    sid: RoomSid
+    uid: UID
+    createdAt: number
+    updatedAt: number
+    password: string
+    parameters?: Record<string | number, unknown>
+}

--- a/functions/src/types/UserData.ts
+++ b/functions/src/types/UserData.ts
@@ -1,6 +1,6 @@
 import * as admin from 'firebase-admin'
 import Timestamp = admin.firestore.Timestamp
-import { UID } from '../../../types/uid'
+import { UID } from '../types/uid'
 
 export interface UserData {
     id: UID

--- a/functions/src/types/uid.ts
+++ b/functions/src/types/uid.ts
@@ -1,0 +1,1 @@
+export type UID = string

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1,6 +1,6 @@
 import { JWTToken } from '../../types/JWT'
 import { SET_TOKEN } from '../actions/types'
 
-export const setToken = (token: JWTToken) => {
+export const setToken = (token: JWTToken | null) => {
     return { type: SET_TOKEN, payload: { token } }
 }

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -6,7 +6,6 @@ import { IonApp, IonHeader } from '@ionic/react'
 import SwipeableTemporaryDrawer from '../SwipeableTemporaryDrawer/SwipeableTemporaryDrawer'
 import { Navbar } from 'react-bootstrap'
 import useDetectMobileOrTablet from '../../hooks/useDetectMobileOrTablet'
-import useAnonymousLogin from '../../hooks/useAnonymousLogin'
 import styled from 'styled-components'
 import { IonReactRouter } from '@ionic/react-router'
 import Login from '../Login'
@@ -53,24 +52,21 @@ const App = () => {
         gdprHandler()
     }, [])
 
-    useAnonymousLogin(token)
-
     return (
         <IonApp className="App">
             <Login />
-            {token && (
-                <IonReactRouter>
-                    {isMobile && (
-                        <IonHeader id="topbar">
-                            <Navbar bg="light" variant="dark">
-                                <SwipeableTemporaryDrawer />
-                                <NavbarContainer />
-                            </Navbar>
-                        </IonHeader>
-                    )}
-                    <Router />
-                </IonReactRouter>
-            )}
+
+            <IonReactRouter>
+                {isMobile && (
+                    <IonHeader id="topbar">
+                        <Navbar bg="light" variant="dark">
+                            <SwipeableTemporaryDrawer />
+                            <NavbarContainer />
+                        </Navbar>
+                    </IonHeader>
+                )}
+                <Router />
+            </IonReactRouter>
         </IonApp>
     )
 }

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -9,8 +9,6 @@ import useDetectMobileOrTablet from '../../hooks/useDetectMobileOrTablet'
 import styled from 'styled-components'
 import { IonReactRouter } from '@ionic/react-router'
 import Login from '../Login'
-import { useSelector } from 'react-redux'
-import { selectToken } from '../../utils/selectors'
 
 declare global {
     interface Window {
@@ -27,7 +25,6 @@ const NavbarContainer = styled.div`
 
 const App = () => {
     const isMobile = useDetectMobileOrTablet()
-    const token = useSelector(selectToken)
 
     useEffect(() => {
         // when using vh and vw units in css:

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -52,6 +52,7 @@ const Login = () => {
     const logout = useCallback(() => {
         authInstance.signOut()
         setIsLoggedIn(false)
+        dispatch(actions.setToken(null))
     }, [setIsLoggedIn])
 
     useEffect(() => {

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -53,7 +53,7 @@ const Login = () => {
         authInstance.signOut()
         setIsLoggedIn(false)
         dispatch(actions.setToken(null))
-    }, [setIsLoggedIn])
+    }, [dispatch, setIsLoggedIn])
 
     useEffect(() => {
         const fetchTokenHandleLoginState = async (user: firebase.User) => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,4 +6,13 @@ export const EMULATORS = {
     },
 }
 
-export const TEST_USER = { email: 'test@email.com', password: 'test-password' }
+export const TEST_ACCOUNTS = [
+    {
+        email: 'test-account-1@gmail.com',
+        password: 'test-password-1',
+    },
+    {
+        email: 'test-account-2@gmail.com',
+        password: 'test-password-1',
+    },
+]

--- a/src/pages/Home/EmulatorLogin.tsx
+++ b/src/pages/Home/EmulatorLogin.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { Button } from 'react-bootstrap'
+import { Link } from 'react-router-dom'
+import { TEST_ACCOUNTS } from '../../constants'
+import { signInEmulatorEmailPassword } from '../../utils/emulators'
+
+const [FIRST_TEST_ACCOUNT, SECOND_TEST_ACCOUNT] = TEST_ACCOUNTS
+
+export const EmulatorLogin = ({ authInstance, token }) => {
+    const signInWithEmailAndPassword = async ({ email, password }) => {
+        try {
+            const user = await signInEmulatorEmailPassword(
+                authInstance,
+                email,
+                password
+            )
+            console.log('Signed In with user: ', user)
+        } catch (error) {
+            const { code, message } = error
+            console.log(`Error email auth: ${code}, message: ${message}`)
+        }
+    }
+    return (
+        <>
+            <span>Emulator Signin: </span>
+            <Button onClick={() => authInstance.signInAnonymously()}>
+                Anonymous
+            </Button>
+            {token && (
+                <Button
+                    onClick={() => {
+                        authInstance.signOut()
+                    }}>
+                    Sign out
+                </Button>
+            )}
+            <Button
+                onClick={() => signInWithEmailAndPassword(FIRST_TEST_ACCOUNT)}>
+                Email (1)
+            </Button>
+            <Button
+                onClick={() => signInWithEmailAndPassword(SECOND_TEST_ACCOUNT)}>
+                Email (2)
+            </Button>
+            <Link to="premium-video">Go to Premium Video</Link>
+        </>
+    )
+}

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -18,10 +18,10 @@ import useDetectMobileOrTablet from '../../hooks/useDetectMobileOrTablet'
 import { IonContent } from '@ionic/react'
 import * as LocalStorage from '../../services/local-storage'
 import { authInstance } from '../../firebase/firebase'
-import {
-    signInWithAuthEmulator,
-    isAuthEmulatorEnabled,
-} from '../../utils/emulators'
+import { isAuthEmulatorEnabled } from '../../utils/emulators'
+import { selectToken } from '../../utils/selectors'
+import { useSelector } from 'react-redux'
+import { EmulatorLogin } from './EmulatorLogin'
 
 const DataMentions = styled.div`
     .cnil {
@@ -56,6 +56,7 @@ const KnowMoreMobile = styled.p`
 
 export default function Home() {
     const { t } = useTranslation(['home', 'common'])
+    const token = useSelector(selectToken)
     const [videoCallId, setVideoCallId] = useState()
     const [error, setError] = useState()
     const isMobile = useDetectMobileOrTablet()
@@ -85,13 +86,7 @@ export default function Home() {
     return (
         <IonContent>
             {isAuthEmulatorEnabled() && (
-                <>
-                    <button
-                        onClick={() => signInWithAuthEmulator(authInstance)}>
-                        EMULATOR SIGN-IN
-                    </button>
-                    <Link to="premium-video">Go to Twilio Video</Link>
-                </>
+                <EmulatorLogin authInstance={authInstance} token={token} />
             )}
 
             {!isMobile ? (

--- a/src/pages/PremiumVideoCall/components/PreJoinScreens/DeviceSelectionScreen/DeviceSelectionScreen.tsx
+++ b/src/pages/PremiumVideoCall/components/PreJoinScreens/DeviceSelectionScreen/DeviceSelectionScreen.tsx
@@ -22,6 +22,7 @@ import useVideoContext from '../../../hooks/useVideoContext/useVideoContext'
 import { Api } from '../../../../../services/api'
 import { selectToken } from '../../../../../utils/selectors'
 import { useSelector } from 'react-redux'
+import { RoomId } from '../../../../../../types/Room'
 
 const useStyles = makeStyles((theme: Theme) => ({
     gutterBottom: {
@@ -67,13 +68,13 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 interface DeviceSelectionScreenProps {
     name: string
-    roomName: string
+    roomId: RoomId
     setStep: (step: Steps) => void
 }
 
 export default function DeviceSelectionScreen({
     name,
-    roomName,
+    roomId,
     setStep,
 }: DeviceSelectionScreenProps) {
     const classes = useStyles()
@@ -82,24 +83,17 @@ export default function DeviceSelectionScreen({
     const { connect, isAcquiringLocalTracks, isConnecting } = useVideoContext()
     const disableButtons = isFetching || isAcquiringLocalTracks || isConnecting
 
-    const handleJoin = () => {
+    const handleJoin = async () => {
         const api = new Api(token)
-        api.createRoom()
-            .then((response) => response.roomId)
-            .then((roomId) => {
-                return api.joinRoom(roomId)
-            })
-            .then((response) => {
-                const { jwtAccessToken } = response
-                return jwtAccessToken
-            })
-            .then((jwtAccessToken) => connect(jwtAccessToken))
+        const response = await api.joinRoom(roomId, 'test-password') // TODO pass the password variable
+        const { jwtAccessToken } = response
+        connect(jwtAccessToken, roomId)
     }
 
     return (
         <>
             <Typography variant="h5" className={classes.gutterBottom}>
-                Join {roomName}
+                Join {roomId}
             </Typography>
 
             <Grid container justify="center">
@@ -152,7 +146,7 @@ export default function DeviceSelectionScreen({
                                 variant="contained"
                                 color="primary"
                                 data-cy-join-now
-                                onClick={handleJoin}
+                                onClick={() => handleJoin()}
                                 disabled={disableButtons}>
                                 Join Now
                             </Button>

--- a/src/pages/PremiumVideoCall/components/PreJoinScreens/DeviceSelectionScreen/DeviceSelectionScreen.tsx
+++ b/src/pages/PremiumVideoCall/components/PreJoinScreens/DeviceSelectionScreen/DeviceSelectionScreen.tsx
@@ -85,8 +85,7 @@ export default function DeviceSelectionScreen({
 
     const handleJoin = async () => {
         const api = new Api(token)
-        const response = await api.joinRoom(roomId, 'test-password') // TODO pass the password variable
-        const { jwtAccessToken } = response
+        const { jwtAccessToken } = await api.joinRoom(roomId, 'test-password') // TODO pass the password variable
         connect(jwtAccessToken, roomId)
     }
 

--- a/src/pages/PremiumVideoCall/components/PreJoinScreens/PreJoinScreens.tsx
+++ b/src/pages/PremiumVideoCall/components/PreJoinScreens/PreJoinScreens.tsx
@@ -87,7 +87,7 @@ export default function PreJoinScreens() {
             {step === Steps.deviceSelectionStep && (
                 <DeviceSelectionScreen
                     name={name}
-                    roomName={roomName}
+                    roomId={roomName}
                     setStep={setStep}
                 />
             )}

--- a/src/pages/PremiumVideoCall/components/PreJoinScreens/PreflightTest/useGetPreflightTokens/useGetPreflightTokens.ts
+++ b/src/pages/PremiumVideoCall/components/PreJoinScreens/PreflightTest/useGetPreflightTokens/useGetPreflightTokens.ts
@@ -9,7 +9,7 @@ import { useState, useEffect } from 'react'
 import { JWTToken } from '../../../../../../../types/JWT'
 
 export default function useGetPreflightTokens(instantVisioToken: JWTToken) {
-    const { getToken } = useAppState()
+    const { getTwilioVideoToken } = useAppState()
     const [tokens, setTokens] = useState<[string, string]>()
     const [tokenError, setTokenError] = useState<Error>()
     const [isFetching, setIsFetching] = useState(false)
@@ -24,8 +24,16 @@ export default function useGetPreflightTokens(instantVisioToken: JWTToken) {
             const subscriberIdentity = 'participant-' + nanoid()
 
             Promise.all([
-                getToken(instantVisioToken, publisherIdentity, roomName),
-                getToken(instantVisioToken, subscriberIdentity, roomName),
+                getTwilioVideoToken(
+                    instantVisioToken,
+                    publisherIdentity,
+                    roomName
+                ),
+                getTwilioVideoToken(
+                    instantVisioToken,
+                    subscriberIdentity,
+                    roomName
+                ),
             ])
                 .then((tokens) => {
                     setTokens(tokens)
@@ -33,7 +41,7 @@ export default function useGetPreflightTokens(instantVisioToken: JWTToken) {
                 })
                 .catch((error) => setTokenError(error))
         }
-    }, [getToken, isFetching, tokens, instantVisioToken])
+    }, [getTwilioVideoToken, isFetching, tokens, instantVisioToken])
 
     return { tokens, tokenError }
 }

--- a/src/pages/PremiumVideoCall/components/VideoProvider/index.tsx
+++ b/src/pages/PremiumVideoCall/components/VideoProvider/index.tsx
@@ -34,7 +34,7 @@ export interface IVideoContext {
     room: Room
     localTracks: (LocalAudioTrack | LocalVideoTrack)[]
     isConnecting: boolean
-    connect: (token: string) => Promise<void>
+    connect: (token: string, roomId: string) => Promise<void>
     onError: ErrorCallback
     onDisconnect: Callback
     getLocalVideoTrack: (

--- a/src/pages/PremiumVideoCall/components/VideoProvider/useRoom/useRoom.tsx
+++ b/src/pages/PremiumVideoCall/components/VideoProvider/useRoom/useRoom.tsx
@@ -28,11 +28,12 @@ export default function useRoom(
     }, [options])
 
     const connect = useCallback(
-        (token) => {
+        (token, roomId) => {
             setIsConnecting(true)
             return Video.connect(token, {
                 ...optionsRef.current,
                 tracks: localTracks,
+                name: roomId,
             }).then(
                 (newRoom) => {
                     setRoom(newRoom)

--- a/src/pages/PremiumVideoCall/state/index.tsx
+++ b/src/pages/PremiumVideoCall/state/index.tsx
@@ -21,7 +21,7 @@ import { JWTToken } from '../../../../types/JWT'
 export interface StateContextType {
     error: TwilioError | null
     setError(error: TwilioError | null): void
-    getToken(
+    getTwilioVideoToken(
         instantVisioToken: JWTToken,
         name: string,
         room: string,
@@ -85,7 +85,7 @@ export default function AppStateProvider(props: React.PropsWithChildren<{}>) {
     } else {
         contextValue = {
             ...contextValue,
-            getToken: async (identity, roomName) => {
+            getTwilioVideoToken: async (identity, roomName) => {
                 const headers = new window.Headers()
                 const endpoint =
                     process.env.REACT_APP_TOKEN_ENDPOINT || '/token'
@@ -101,14 +101,14 @@ export default function AppStateProvider(props: React.PropsWithChildren<{}>) {
         }
     }
 
-    const getToken: StateContextType['getToken'] = (
+    const getTwilioVideoToken: StateContextType['getTwilioVideoToken'] = (
         instantVisioToken,
         name,
         room
     ) => {
         setIsFetching(true)
         return contextValue
-            .getToken(instantVisioToken, name, room)
+            .getTwilioVideoToken(instantVisioToken, name, room)
             .then((res) => {
                 setIsFetching(false)
                 return res
@@ -121,7 +121,7 @@ export default function AppStateProvider(props: React.PropsWithChildren<{}>) {
     }
 
     return (
-        <StateContext.Provider value={{ ...contextValue, getToken }}>
+        <StateContext.Provider value={{ ...contextValue, getTwilioVideoToken }}>
             {props.children}
         </StateContext.Provider>
     )

--- a/src/pages/PremiumVideoCall/state/usePasscodeAuth/usePasscodeAuth.ts
+++ b/src/pages/PremiumVideoCall/state/usePasscodeAuth/usePasscodeAuth.ts
@@ -24,7 +24,7 @@ export async function fetchTwilioVideoToken(
     password: string
 ) {
     const api = new Api(instantVisioToken)
-    const response = await api.joinRoom(roomId, password)
+    const  { jwtAccessToken } = await api.joinRoom(roomId, password)
     const { jwtAccessToken } = response
     return jwtAccessToken
 }

--- a/src/pages/PremiumVideoCall/state/usePasscodeAuth/usePasscodeAuth.ts
+++ b/src/pages/PremiumVideoCall/state/usePasscodeAuth/usePasscodeAuth.ts
@@ -25,7 +25,6 @@ export async function fetchTwilioVideoToken(
 ) {
     const api = new Api(instantVisioToken)
     const  { jwtAccessToken } = await api.joinRoom(roomId, password)
-    const { jwtAccessToken } = response
     return jwtAccessToken
 }
 

--- a/src/pages/PremiumVideoCall/state/usePasscodeAuth/usePasscodeAuth.ts
+++ b/src/pages/PremiumVideoCall/state/usePasscodeAuth/usePasscodeAuth.ts
@@ -8,6 +8,7 @@ import { useHistory } from 'react-router-dom'
 import { RoomType } from '../../types'
 import { Api } from '../../../../services/api'
 import { JWTToken } from '../../../../../types/JWT'
+import { RoomId } from '../../../../../types/Room'
 
 export function getPasscode() {
     const match = window.location.search.match(/passcode=(.*)&?/)
@@ -17,26 +18,15 @@ export function getPasscode() {
     return passcode
 }
 
-export function fetchToken(
+export async function fetchTwilioVideoToken(
     instantVisioToken: JWTToken,
-    name: string,
-    room: string,
-    passcode: string,
-    create_room = true
+    roomId: RoomId,
+    password: string
 ) {
     const api = new Api(instantVisioToken)
-    return api
-        .createRoom()
-        .then((response) => {
-            return response.roomId
-        })
-        .then((roomId) => {
-            return api.joinRoom(roomId)
-        })
-        .then((response) => {
-            const { jwtAccessToken } = response
-            return jwtAccessToken
-        })
+    const response = await api.joinRoom(roomId, password)
+    const { jwtAccessToken } = response
+    return jwtAccessToken
 }
 
 export async function verifyPasscode(passcode: string) {
@@ -65,17 +55,23 @@ export default function usePasscodeAuth() {
     const [isAuthReady, setIsAuthReady] = useState(false)
     const [roomType, setRoomType] = useState<RoomType>()
 
-    const getToken = useCallback(
-        (instantVisioToken: string, name: string, room: string) => {
-            return fetchToken(
+    const getTwilioVideoToken = useCallback(
+        (instantVisioToken: string, roomId: RoomId) => {
+            const fetchTokenAndSetRoomType = async (
                 instantVisioToken,
-                name,
-                room,
-                user!.passcode
-            ).then((token) => {
+                roomId
+            ) => {
+                const token = await fetchTwilioVideoToken(
+                    instantVisioToken,
+                    roomId,
+                    user!.passcode
+                )
+
                 setRoomType('group')
                 return token as string
-            })
+            }
+
+            return fetchTokenAndSetRoomType(instantVisioToken, roomId)
         },
         [user]
     )
@@ -115,5 +111,5 @@ export default function usePasscodeAuth() {
         return Promise.resolve()
     }, [])
 
-    return { user, isAuthReady, getToken, signIn, signOut, roomType }
+    return { user, isAuthReady, getTwilioVideoToken, signIn, signOut, roomType }
 }

--- a/src/reducers/rootReducer.ts
+++ b/src/reducers/rootReducer.ts
@@ -2,11 +2,11 @@ import { JWTToken } from '../../types/JWT'
 import { SetTokenAction, SET_TOKEN } from '../actions/types'
 
 export interface AppState {
-    token: JWTToken
+    token: JWTToken | null
 }
 
 const initialState = {
-    token: '',
+    token: null,
 }
 
 const rootReducer = (

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,5 +1,6 @@
 import { JWTToken } from '../../types/JWT'
 import { JoinRoomResponse } from '../../types/JoinRoomResponse'
+import { NewRoomResponse } from '../../types/NewRoomResponse'
 import { RoomId } from '../../types/Room'
 export class Api {
     baseUrl: string | undefined
@@ -10,6 +11,10 @@ export class Api {
             throw new Error('API url is missing from env configuration')
         }
         this.jwtToken = jwtToken
+    }
+
+    async createRoom(password?: string): Promise<NewRoomResponse> {
+        return this.post('/rooms/new', password ? { password } : null)
     }
 
     async joinRoom(

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,6 +1,6 @@
 import { JWTToken } from '../../types/JWT'
-import { NewRoomResponse } from '../../types/NewRoomResponse'
 import { JoinRoomResponse } from '../../types/JoinRoomResponse'
+import { RoomId } from '../../types/Room'
 export class Api {
     baseUrl: string | undefined
     jwtToken: string
@@ -12,19 +12,11 @@ export class Api {
         this.jwtToken = jwtToken
     }
 
-    async createRoom(): Promise<NewRoomResponse> {
-        const data = {
-            password: 'password=test-password',
-        }
-
-        return this.post('/rooms/new', data)
-    }
-
-    async joinRoom(roomId: string): Promise<JoinRoomResponse> {
-        const data = {
-            password: 'password=test-password',
-        }
-        return this.post(`/rooms/${roomId}/join`, data)
+    async joinRoom(
+        roomId: RoomId,
+        password: string
+    ): Promise<JoinRoomResponse> {
+        return this.post(`/rooms/${roomId}/join`, { password })
     }
 
     async post(apiUrl: string, data: any): Promise<any> {

--- a/src/utils/emulators.ts
+++ b/src/utils/emulators.ts
@@ -1,10 +1,8 @@
-import { TEST_USER } from '../constants'
-import 'firebase/auth'
-
-export const signInWithAuthEmulator = async (
-    authInstance: firebase.auth.Auth
-): Promise<void> => {
-    const { email, password } = TEST_USER
+export const signInEmulatorEmailPassword = async (
+    authInstance: firebase.auth.Auth,
+    email: string,
+    password: string
+): Promise<firebase.auth.UserCredential | undefined> => {
     try {
         const signInResult = await authInstance.createUserWithEmailAndPassword(
             email,
@@ -12,6 +10,7 @@ export const signInWithAuthEmulator = async (
         )
 
         console.log('SignIn Success:', signInResult)
+        return signInResult
     } catch (error) {
         if (error.code === 'auth/email-already-in-use') {
             console.log('SignIn error: account already exists ', error)
@@ -21,7 +20,7 @@ export const signInWithAuthEmulator = async (
                     password
                 )
                 console.log('Login Success:', loginResult)
-                return
+                return loginResult
             } catch (error) {
                 console.log('Login error:', error)
             }


### PR DESCRIPTION
This PR allowed to test joining a call with 2 participants locally:

- Replace `createRoom` call with `joinRoom` only, since it now takes care of creating the room if it does not exist yet, and if the user has the rights to
- fix logout button issue (corresponding action was not being dispatched)
- set functions types back to `./functions/src/types` in order to avoid `tsc` transpiration issues (due to the use of relative paths to access the types declared in `<rootProject>/types` as `../../types` from `firebase functions`
- Email/password login with emulator
- Remove anonymous login by default when using emulator, add a button to login anonymously instead

I used a basic UI to interact with the emulator and simulate user logins

<img width="1424" alt="Screenshot 2020-12-11 at 17 03 26" src="https://user-images.githubusercontent.com/11927970/101925971-d48b4500-3bd2-11eb-926e-59dd68a1a070.png">


### To review
- review by commit (no need to review the first one, as I only moved back the functions `types`, where they were originally
