### PR TITLE
Invite Participants by email basic form

### DIFF
--- a/public/locales/en/add-participants-form.json
+++ b/public/locales/en/add-participants-form.json
@@ -8,6 +8,6 @@
     },
     "placeholder": "Type participants addresses ...",
     "errors": {
-        "inviteParticipants": "An error occurred while trying to send invites"
+        "general": "An error occurred while trying to send invites"
     }
 }

--- a/public/locales/en/add-participants-form.json
+++ b/public/locales/en/add-participants-form.json
@@ -1,0 +1,13 @@
+{
+    "title": "Add participants",
+    "description": "Note here all telephone numbers and email addresses to which you want to send an invite. You can also add a group name.",
+    "notice": "Telephone numbers must not contain any 'space' caracters",
+    "buttons": {
+        "cancel": "Cancel",
+        "submit": "I confirm"
+    },
+    "placeholder": "Type participants addresses ...",
+    "errors": {
+        "inviteParticipants": "An error occurred while trying to send invites"
+    }
+}

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1,6 +1,17 @@
 import { JWTToken } from '../../types/JWT'
+import { RoomId } from '../../types/Room'
 import { SET_TOKEN } from '../actions/types'
+import { SET_ROOM_ID } from '../actions/types'
+import { SET_HOST_NAME } from '../actions/types'
 
 export const setToken = (token: JWTToken | null) => {
     return { type: SET_TOKEN, payload: { token } }
+}
+
+export const setRoomId = (roomId: RoomId | null) => {
+    return { type: SET_ROOM_ID, payload: { roomId } }
+}
+
+export const setHostName = (hostName: string | null) => {
+    return { type: SET_HOST_NAME, payload: { hostName } }
 }

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -1,6 +1,9 @@
 import { JWTToken } from '../../types/JWT'
+import { RoomId } from '../../types/Room'
 
 export const SET_TOKEN = 'SET_TOKEN'
+export const SET_ROOM_ID = 'SET_ROOM_ID'
+export const SET_HOST_NAME = 'SET_HOST_NAME'
 
 export interface Token {
     token: JWTToken
@@ -11,4 +14,14 @@ export interface SetTokenAction {
     payload: Token
 }
 
-export type ActionTypes = SetTokenAction
+export interface SetRoomIdAction {
+    type: typeof SET_ROOM_ID
+    payload: { roomId: RoomId }
+}
+
+export interface SetHostNameAction {
+    type: typeof SET_HOST_NAME
+    payload: { hostName: string }
+}
+
+export type ActionTypes = SetTokenAction | SetRoomIdAction | SetHostNameAction

--- a/src/components/InviteParticipants/InviteForm.tsx
+++ b/src/components/InviteParticipants/InviteForm.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import { useTranslation } from 'react-i18next'
 import classNames from 'classnames'
 import Field from '../Form/Field'
-import CallError, { Error } from '../Form/CallError'
+import CallError from '../Form/CallError'
 
 const BootstrapForm = styled(BaseForm)`
     width: 100%;

--- a/src/components/InviteParticipants/InviteForm.tsx
+++ b/src/components/InviteParticipants/InviteForm.tsx
@@ -44,12 +44,8 @@ const FormSubmit = styled.div`
     }
 `
 
-export default function InviteForm({ onSubmit }) {
+export default function InviteForm({ onSubmit, error }) {
     const { t } = useTranslation('add-participants-form')
-    const error: Error = {
-        code: '500',
-        message: t('errors.inviteParticipants'),
-    }
 
     const initialValues = {
         participantAddresses: [],

--- a/src/components/InviteParticipants/InviteForm.tsx
+++ b/src/components/InviteParticipants/InviteForm.tsx
@@ -1,0 +1,118 @@
+import React from 'react'
+import { Formik } from 'formik'
+import { Form as BaseForm, Button } from 'react-bootstrap'
+import styled from 'styled-components'
+import { useTranslation } from 'react-i18next'
+import classNames from 'classnames'
+import Field from '../Form/Field'
+import CallError, { Error } from '../Form/CallError'
+
+const BootstrapForm = styled(BaseForm)`
+    width: 100%;
+`
+
+const FormFields = styled.div`
+    & > * {
+        margin: 0 0 ${({ theme }) => theme.spacing.XXL};
+    }
+
+    &:first-child {
+        margin-top: ${({ theme }) => theme.spacing.XXL};
+    }
+`
+
+const SubmitError = styled.p`
+    color: ${({ theme }) => theme.color.red};
+`
+
+const FormCardHeader = styled.div`
+    & p {
+        &:first-child {
+            text-align: center;
+            font-weight: bold;
+            font-size: ${({ theme }) => theme.font.XL};
+            color: ${({ theme }) => theme.color.orange};
+        }
+    }
+`
+
+const FormSubmit = styled.div`
+    margin-bottom: ${({ theme }) => theme.spacing.XXL};
+    text-align: center;
+    Button {
+        margin: ${({ theme }) => theme.spacing.XXS};
+    }
+`
+
+export default function InviteForm({ onSubmit }) {
+    const { t } = useTranslation('add-participants-form')
+    const error: Error = {
+        code: '500',
+        message: t('errors.inviteParticipants'),
+    }
+
+    const initialValues = {
+        participantAddresses: [],
+    }
+
+    const onValidate = async (values) => {
+        // TODO add validation logic
+        console.log('Values: ', values)
+        return true
+    }
+
+    return (
+        <>
+            <FormCardHeader>
+                <p>{t('title')}</p>
+                <p>{t('description')}</p>
+            </FormCardHeader>
+            <Formik
+                initialValues={initialValues}
+                validateOnBlur={false}
+                validateOnChange={false}
+                validate={onValidate}
+                onSubmit={onSubmit}>
+                {(props) => {
+                    /* eslint-disable react/prop-types */
+                    const { isSubmitting, handleSubmit } = props
+                    return (
+                        <BootstrapForm onSubmit={handleSubmit} noValidate>
+                            <FormFields>
+                                <Field
+                                    name="participantAddresses"
+                                    type="text"
+                                    disabled={isSubmitting}
+                                    placeholder={t('placeholder')}
+                                    label={t('notice')}
+                                    title={t('personName.title')}
+                                />
+                            </FormFields>
+                            <FormSubmit>
+                                <Button
+                                    type="submit"
+                                    disabled={isSubmitting}
+                                    className={classNames({
+                                        loading: isSubmitting,
+                                    })}>
+                                    {t('buttons.cancel')}
+                                </Button>
+                                <Button
+                                    type="submit"
+                                    disabled={isSubmitting}
+                                    className={classNames({
+                                        loading: isSubmitting,
+                                    })}>
+                                    {t('buttons.submit')}
+                                </Button>
+                            </FormSubmit>
+                            {error && (
+                                <SubmitError>{CallError(error, t)}</SubmitError>
+                            )}
+                        </BootstrapForm>
+                    )
+                }}
+            </Formik>
+        </>
+    )
+}

--- a/src/components/InviteParticipants/InviteParticipants.tsx
+++ b/src/components/InviteParticipants/InviteParticipants.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react'
+import InviteForm from './InviteForm'
+import Modal from '../Modal/Modal'
+import Button from '@material-ui/core/Button'
+import { selectToken } from '../../utils/selectors'
+import { useSelector } from 'react-redux'
+import { Api } from '../../services/api'
+
+const InviteParticipants = () => {
+    const token = useSelector(selectToken)
+    const [isModalOpened, setIsModalOpened] = useState(false)
+
+    const onSubmit = (values, { setSubmitting }) => {
+        const { participantAddresses } = values
+        const addresses = participantAddresses.split(' ').map((email) => ({
+            email,
+            lang: 'fr',
+        }))
+        console.log('On submit called: ', addresses)
+
+        try {
+            const api = new Api(token)
+            api.inviteParticipants('fake-room-id', 'test-hostname', addresses)
+        } catch (e) {
+            console.log('An error occurred inviting participants')
+        }
+        setSubmitting(false)
+        setIsModalOpened(false)
+    }
+
+    const handleClose = () => {
+        setIsModalOpened(false)
+    }
+
+    const handleOpen = () => {
+        setIsModalOpened(true)
+    }
+
+    return (
+        <>
+            <Button onClick={handleOpen}>Add participants</Button>
+
+            <Modal isOpened={isModalOpened} onClose={handleClose}>
+                <InviteForm onSubmit={onSubmit} />
+            </Modal>
+        </>
+    )
+}
+
+export default InviteParticipants

--- a/src/components/InviteParticipants/InviteParticipants.tsx
+++ b/src/components/InviteParticipants/InviteParticipants.tsx
@@ -5,12 +5,23 @@ import Button from '@material-ui/core/Button'
 import { selectToken } from '../../utils/selectors'
 import { useSelector } from 'react-redux'
 import { Api } from '../../services/api'
+import { RoomId } from '../../../types/Room'
 
-const InviteParticipants = () => {
+const InviteParticipants = ({
+    roomId,
+    hostName,
+}: {
+    roomId: RoomId
+    hostName: string
+}) => {
     const token = useSelector(selectToken)
     const [isModalOpened, setIsModalOpened] = useState(false)
+    const [hasError, setHasError] = useState(false)
+    const error = {
+        code: '500',
+    }
 
-    const onSubmit = (values, { setSubmitting }) => {
+    const onSubmit = async (values, { setSubmitting }) => {
         const { participantAddresses } = values
         const addresses = participantAddresses.split(' ').map((email) => ({
             email,
@@ -20,12 +31,13 @@ const InviteParticipants = () => {
 
         try {
             const api = new Api(token)
-            api.inviteParticipants('fake-room-id', 'test-hostname', addresses)
+            await api.inviteParticipants(roomId, hostName, addresses)
+            setTimeout(() => setIsModalOpened(false), 500)
         } catch (e) {
-            console.log('An error occurred inviting participants')
+            console.log('An error occurred inviting participants: ', e)
+            setHasError(true)
         }
         setSubmitting(false)
-        setIsModalOpened(false)
     }
 
     const handleClose = () => {
@@ -41,7 +53,10 @@ const InviteParticipants = () => {
             <Button onClick={handleOpen}>Add participants</Button>
 
             <Modal isOpened={isModalOpened} onClose={handleClose}>
-                <InviteForm onSubmit={onSubmit} />
+                <InviteForm
+                    onSubmit={onSubmit}
+                    error={hasError ? error : false}
+                />
             </Modal>
         </>
     )

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles'
+import { Modal as MaterialModal } from '@material-ui/core'
+
+function getModalStyle() {
+    const top = 30
+    const left = 30
+
+    return {
+        top: `${top}%`,
+        left: `${left}%`,
+        transform: `translate(-${top}%, -${left}%)`,
+    }
+}
+
+const useStyles = makeStyles((theme: Theme) =>
+    createStyles({
+        paper: {
+            position: 'absolute',
+            width: 400,
+            backgroundColor: theme.palette.background.paper,
+            border: '2px solid #000',
+            boxShadow: theme.shadows[5],
+            padding: theme.spacing(2, 4, 3),
+        },
+    })
+)
+
+export default function Modal({ isOpened, children, onClose }) {
+    const classes = useStyles()
+    const [modalStyle] = React.useState(getModalStyle)
+
+    const body = (
+        <div style={modalStyle} className={classes.paper}>
+            {children}
+        </div>
+    )
+
+    return (
+        <div>
+            <MaterialModal
+                open={isOpened}
+                onClose={onClose}
+                aria-labelledby="simple-modal-title"
+                aria-describedby="simple-modal-description">
+                {body}
+            </MaterialModal>
+        </div>
+    )
+}

--- a/src/pages/PremiumVideoCall/components/MenuBar/MenuBar.tsx
+++ b/src/pages/PremiumVideoCall/components/MenuBar/MenuBar.tsx
@@ -17,6 +17,9 @@ import { Typography, Grid, Hidden } from '@material-ui/core'
 import ToggleAudioButton from '../Buttons/ToggleAudioButton/ToggleAudioButton'
 import ToggleVideoButton from '../Buttons/ToggleVideoButton/ToggleVideoButton'
 import ToggleScreenShareButton from '../Buttons/ToogleScreenShareButton/ToggleScreenShareButton'
+import InviteParticipants from '../../../../components/InviteParticipants/InviteParticipants'
+import { selectRoomId, selectHostName } from '../../../../utils/selectors'
+import { useSelector } from 'react-redux'
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -73,6 +76,8 @@ export default function MenuBar() {
     const roomState = useRoomState()
     const isReconnecting = roomState === 'reconnecting'
     const { room } = useVideoContext()
+    const roomId = useSelector(selectRoomId)
+    const hostName = useSelector(selectHostName)
 
     return (
         <>
@@ -101,6 +106,10 @@ export default function MenuBar() {
                         <Grid container justify="center">
                             <ToggleAudioButton disabled={isReconnecting} />
                             <ToggleVideoButton disabled={isReconnecting} />
+                            <InviteParticipants
+                                roomId={roomId}
+                                hostName={hostName}
+                            />
                             <Hidden smDown>
                                 {!isSharingScreen && (
                                     <ToggleScreenShareButton

--- a/src/pages/PremiumVideoCall/components/PreJoinScreens/DeviceSelectionScreen/DeviceSelectionScreen.tsx
+++ b/src/pages/PremiumVideoCall/components/PreJoinScreens/DeviceSelectionScreen/DeviceSelectionScreen.tsx
@@ -21,8 +21,9 @@ import { useAppState } from '../../../state'
 import useVideoContext from '../../../hooks/useVideoContext/useVideoContext'
 import { Api } from '../../../../../services/api'
 import { selectToken } from '../../../../../utils/selectors'
-import { useSelector } from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux'
 import { RoomId } from '../../../../../../types/Room'
+import * as actions from '../../../../../actions/actions'
 
 const useStyles = makeStyles((theme: Theme) => ({
     gutterBottom: {
@@ -80,12 +81,15 @@ export default function DeviceSelectionScreen({
     const classes = useStyles()
     const { isFetching } = useAppState()
     const token = useSelector(selectToken)
+    const dispatch = useDispatch()
     const { connect, isAcquiringLocalTracks, isConnecting } = useVideoContext()
     const disableButtons = isFetching || isAcquiringLocalTracks || isConnecting
 
     const handleJoin = async () => {
         const api = new Api(token)
         const { jwtAccessToken } = await api.joinRoom(roomId, 'test-password') // TODO pass the password variable
+        dispatch(actions.setRoomId(roomId))
+        dispatch(actions.setHostName(name))
         connect(jwtAccessToken, roomId)
     }
 

--- a/src/reducers/rootReducer.ts
+++ b/src/reducers/rootReducer.ts
@@ -1,23 +1,43 @@
 import { JWTToken } from '../../types/JWT'
-import { SetTokenAction, SET_TOKEN } from '../actions/types'
+import { RoomId } from '../../types/Room'
+import {
+    ActionTypes,
+    SET_HOST_NAME,
+    SET_ROOM_ID,
+    SET_TOKEN,
+} from '../actions/types'
 
 export interface AppState {
     token: JWTToken | null
+    roomId: RoomId | null
+    hostName: string | null
 }
 
 const initialState = {
     token: null,
+    roomId: null,
+    hostName: null,
 }
 
 const rootReducer = (
     state: AppState = initialState,
-    action: SetTokenAction
+    action: ActionTypes
 ): AppState => {
     switch (action.type) {
         case SET_TOKEN:
             return {
                 ...state,
                 token: action.payload.token,
+            }
+        case SET_ROOM_ID:
+            return {
+                ...state,
+                roomId: action.payload.roomId,
+            }
+        case SET_HOST_NAME:
+            return {
+                ...state,
+                hostName: action.payload.hostName,
             }
         default:
             return state

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -24,6 +24,17 @@ export class Api {
         return this.post(`/rooms/${roomId}/join`, { password })
     }
 
+    async inviteParticipants(
+        roomId: RoomId,
+        hostname: string,
+        destinations: [any]
+    ): Promise<any> {
+        return this.post(`/rooms/${roomId}/inviteParticipants`, {
+            hostname,
+            destinations,
+        })
+    }
+
     async post(apiUrl: string, data: any): Promise<any> {
         const response = await fetch(`${this.baseUrl}${apiUrl}`, {
             method: 'POST',

--- a/src/utils/selectors.ts
+++ b/src/utils/selectors.ts
@@ -1,6 +1,17 @@
 import { createSelector } from 'reselect'
+import { RoomId } from '../../types/Room'
 
 export const selectToken = createSelector(
     (state: any) => state.token,
     (token) => token
+)
+
+export const selectRoomId = createSelector(
+    (state: any) => state.roomId,
+    (roomId: RoomId) => roomId
+)
+
+export const selectHostName = createSelector(
+    (state: any) => state.hostName,
+    (hostName: string) => hostName
 )


### PR DESCRIPTION
- basic participant invite (only allows inserting one or several emails separated by space)
- "placeholder" translations
- network layer to invite the participant
- one generic error message in case of errors
- `Add participants` button within premium video call UI
- generic reusable `Modal` window component
- display invite form component within a Modal on click to "Add participant" button

### Missing
- form validation
- add participants also by phone or group
- set the correct language for the invite

fix #315 