### PR TITLE
Replace footer with drawer menu

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -43,5 +43,10 @@
     "message": {
         "title": "URGENT video call request from",
         "Message": "invites you to a video chat. Join the chat now at this link:"
+    },
+    "appBar": {
+        "appName": "Instant Visio",
+        "joinVisioButton": "Join Visio",
+        "loginButton": "Login"
     }
 }

--- a/src/components/App/AppBar/AppBar.tsx
+++ b/src/components/App/AppBar/AppBar.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
+import { AppBar as MaterialAppBar } from '@material-ui/core'
+import Toolbar from '@material-ui/core/Toolbar'
+import Typography from '@material-ui/core/Typography'
+import Button from '@material-ui/core/Button'
+import SwipeableTemporaryDrawer from '../../SwipeableTemporaryDrawer/SwipeableTemporaryDrawer'
+import styled from 'styled-components'
+
+const useStyles = makeStyles((theme: Theme) =>
+    createStyles({
+        root: {
+            flexGrow: 1,
+            color: 'white',
+        },
+        menuButton: {
+            marginRight: theme.spacing(2),
+        },
+        title: {
+            flexGrow: 1,
+        },
+    })
+)
+
+const WhiteAppBar = styled.div`
+    .MuiAppBar-colorPrimary {
+        background-color: white;
+    }
+`
+
+export default function AppBar() {
+    const classes = useStyles()
+
+    return (
+        <div className={classes.root}>
+            <WhiteAppBar>
+                <MaterialAppBar color="primary" position="static">
+                    <Toolbar>
+                        <Typography
+                            color="primary"
+                            variant="h6"
+                            className={classes.title}>
+                            Instant Visio
+                        </Typography>
+                        <Button color="primary">Join Visio</Button>
+                        <Button color="primary">Login</Button>
+                        <SwipeableTemporaryDrawer />
+                    </Toolbar>
+                </MaterialAppBar>
+            </WhiteAppBar>
+        </div>
+    )
+}

--- a/src/components/App/AppBar/AppBar.tsx
+++ b/src/components/App/AppBar/AppBar.tsx
@@ -6,6 +6,7 @@ import Typography from '@material-ui/core/Typography'
 import Button from '@material-ui/core/Button'
 import SwipeableTemporaryDrawer from '../../SwipeableTemporaryDrawer/SwipeableTemporaryDrawer'
 import styled from 'styled-components'
+import { useTranslation } from 'react-i18next'
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -30,6 +31,7 @@ const WhiteAppBar = styled.div`
 
 export default function AppBar() {
     const classes = useStyles()
+    const { t } = useTranslation('common')
 
     return (
         <div className={classes.root}>
@@ -40,10 +42,14 @@ export default function AppBar() {
                             color="primary"
                             variant="h6"
                             className={classes.title}>
-                            Instant Visio
+                            {t('appBar.appName')}
                         </Typography>
-                        <Button color="primary">Join Visio</Button>
-                        <Button color="primary">Login</Button>
+                        <Button color="primary">
+                            {t('appBar.joinVisioButton')}
+                        </Button>
+                        <Button color="primary">
+                            {t('appBar.loginButton')}
+                        </Button>
                         <SwipeableTemporaryDrawer />
                     </Toolbar>
                 </MaterialAppBar>

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -3,13 +3,10 @@ import './App.scss'
 import { gdprHandler } from '../../utils/gdpr'
 import Router from './Router'
 import { IonApp, IonHeader } from '@ionic/react'
-import SwipeableTemporaryDrawer from '../SwipeableTemporaryDrawer/SwipeableTemporaryDrawer'
-import { Navbar } from 'react-bootstrap'
-import useDetectMobileOrTablet from '../../hooks/useDetectMobileOrTablet'
-import styled from 'styled-components'
 import { IonReactRouter } from '@ionic/react-router'
 import Login from '../Login'
-
+import AppBar from './AppBar/AppBar'
+import styled from 'styled-components'
 declare global {
     interface Window {
         iv: any
@@ -18,14 +15,11 @@ declare global {
     }
 }
 
-const NavbarContainer = styled.div`
-    position: 'relative';
-    margin-left: 40%;
+const StyledRouter = styled.div`
+    margin-top: 1rem;
 `
 
 const App = () => {
-    const isMobile = useDetectMobileOrTablet()
-
     useEffect(() => {
         // when using vh and vw units in css:
         // to make sure the height taken into account
@@ -53,15 +47,12 @@ const App = () => {
         <IonApp className="App">
             <Login />
             <IonReactRouter>
-                {isMobile && (
-                    <IonHeader id="topbar">
-                        <Navbar bg="light" variant="dark">
-                            <SwipeableTemporaryDrawer />
-                            <NavbarContainer />
-                        </Navbar>
-                    </IonHeader>
-                )}
-                <Router />
+                <IonHeader id="topbar">
+                    <AppBar />
+                </IonHeader>
+                <StyledRouter>
+                    <Router />
+                </StyledRouter>
             </IonReactRouter>
         </IonApp>
     )

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,29 +1,9 @@
 import React from 'react'
 import 'bootstrap/dist/css/bootstrap.min.css'
-import { Container } from 'react-bootstrap'
-import { HeaderStyled, HeaderLogoBaseline } from './HeaderStyled'
-import { useTranslation } from 'react-i18next'
-import Logo from '../Logo/Logo'
-import useDetectMobileOrTablet from '../../hooks/useDetectMobileOrTablet'
+import { HeaderStyled } from './HeaderStyled'
 
 const Header = () => {
-    const { t } = useTranslation()
-    const isMobile = useDetectMobileOrTablet()
-
-    return (
-        <HeaderStyled>
-            <Container className="header">
-                <HeaderLogoBaseline>
-                    {!isMobile && <Logo />}
-                    <Container className="header-baseline">
-                        <p className="header-baseline-content">
-                            {t('headerBaseline')}
-                        </p>
-                    </Container>
-                </HeaderLogoBaseline>
-            </Container>
-        </HeaderStyled>
-    )
+    return <HeaderStyled></HeaderStyled>
 }
 
 export default React.memo(Header)

--- a/src/components/SwipeableTemporaryDrawer/SwipeableTemporaryDrawer.tsx
+++ b/src/components/SwipeableTemporaryDrawer/SwipeableTemporaryDrawer.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import clsx from 'clsx'
-import { makeStyles } from '@material-ui/core/styles'
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import SwipeableDrawer from '@material-ui/core/SwipeableDrawer'
 import MenuIcon from '@material-ui/icons/Menu'
 import Divider from '@material-ui/core/Divider'
@@ -18,23 +18,42 @@ import PersonIcon from '@material-ui/icons/Person'
 import InfoIcon from '@material-ui/icons/Info'
 import { IonItem, IonList } from '@ionic/react'
 import Lang from '../Lang/Lang'
+import { IconButton } from '@material-ui/core'
+import { Link } from 'react-router-dom'
+import NewsletterModal from '../../pages/Newsletter/NewsletterModal'
+import { showPreferencesDialog } from '../../utils/gdpr'
+import About from '../../documents/Instant_Visio_Keynote.pdf'
 
 const LogoContainer = styled.div`
-    padding-left: 25%;
-    padding-right: 25%;
+    padding-left: 35%;
+    padding-right: 35%;
 `
 
-const useStyles = makeStyles({
-    list: {
-        width: 250,
-    },
-    fullList: {
-        width: 'auto',
-    },
-    languagePicker: {
-        marginLeft: '1rem',
-    },
-})
+const StyledItem = styled.div`
+    width: 100%;
+
+    .MuiListItem-gutters {
+        padding-left: 0;
+        padding-right: 0;
+    }
+`
+
+const useStyles = makeStyles((theme: Theme) =>
+    createStyles({
+        list: {
+            width: 250,
+        },
+        fullList: {
+            width: 'auto',
+        },
+        languagePicker: {
+            marginLeft: '1rem',
+        },
+        menuButton: {
+            marginLeft: theme.spacing(2),
+        },
+    })
+)
 
 export default function SwipeableTemporaryDrawer() {
     const classes = useStyles()
@@ -97,30 +116,109 @@ export default function SwipeableTemporaryDrawer() {
                             url: `/${t('url.personal-data')}`,
                         },
                         {
-                            title: t('footer.about'),
+                            title: t('footer.credits'),
                             icon: <InfoIcon />,
                             url: `/${t('url.credits')}`,
                         },
+                        {
+                            url: `/${t('url.blog')}`,
+                            icon: <InfoIcon />,
+                            title: t('footer.blog'),
+                        },
+                        {
+                            url: `/${t('url.media')}`,
+                            icon: <InfoIcon />,
+                            title: t('footer.media'),
+                        },
+                        {
+                            url: `/${t('url.license')}`,
+                            icon: <InfoIcon />,
+                            title: t('footer.license'),
+                        },
                     ].map(({ title, icon, url }) => (
                         <ListItem button key={title}>
-                            <IonItem routerLink={url}>
-                                <ListItemIcon>{icon}</ListItemIcon>
-                                <ListItemText primary={title} />
-                            </IonItem>
+                            <StyledItem>
+                                <IonItem routerLink={url}>
+                                    <ListItemIcon>{icon}</ListItemIcon>
+                                    <ListItemText primary={title} />
+                                </IonItem>
+                            </StyledItem>
                         </ListItem>
                     ))}
+
+                    <ListItem>
+                        <IonItem>
+                            <ListItemIcon>
+                                <InfoIcon />
+                            </ListItemIcon>
+                            <a
+                                className="footer-link-content"
+                                href={`mailto:contact@instantvisio.com?Subject=${t(
+                                    'footer.contact'
+                                )}`}
+                                target="_blank"
+                                rel="noopener noreferrer">
+                                {t('footer.contact-us')}
+                            </a>{' '}
+                        </IonItem>
+                    </ListItem>
+
+                    <ListItem>
+                        <IonItem>
+                            <ListItemIcon>
+                                <InfoIcon />
+                            </ListItemIcon>
+                            <Link
+                                to={About}
+                                className="footer-link-content"
+                                target="_blank"
+                                rel="noopener noreferrer">
+                                {t('footer.about')}
+                            </Link>
+                        </IonItem>
+                    </ListItem>
+
+                    <ListItem>
+                        <IonItem>
+                            <ListItemIcon>
+                                <InfoIcon />
+                            </ListItemIcon>
+                            <Link to="" className="footer-link-content">
+                                <NewsletterModal />
+                            </Link>
+                        </IonItem>
+                    </ListItem>
+
+                    <ListItem>
+                        <IonItem
+                            routerLink={''}
+                            onClick={showPreferencesDialog}>
+                            <ListItemIcon>
+                                <InfoIcon />
+                            </ListItemIcon>
+                            <ListItemText primary={t('footer.cookies')} />
+                        </IonItem>
+                    </ListItem>
                 </IonList>
                 <Divider />
             </div>
         </div>
     )
 
-    const anchor = 'left'
+    const anchor = 'right'
     return (
         <div>
             {
                 <React.Fragment key={anchor}>
-                    <MenuIcon onClick={toggleDrawer(anchor, true)}></MenuIcon>
+                    <IconButton
+                        edge="end"
+                        className={classes.menuButton}
+                        color="inherit"
+                        onClick={toggleDrawer(anchor, true)}
+                        aria-label="menu">
+                        <MenuIcon color="primary" />
+                    </IconButton>
+
                     <SwipeableDrawer
                         anchor={anchor}
                         open={state[anchor]}

--- a/src/layout/Columns/Columns.tsx
+++ b/src/layout/Columns/Columns.tsx
@@ -3,15 +3,6 @@ import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import useDocumentTitle from '../../hooks/useDocumentTitle'
 import { SCREEN } from '../../styles/theme'
-import Footer from '../../components/Footer/Footer'
-import BaseLang from '../../components/Lang/Lang'
-
-const Lang = styled(BaseLang)`
-    position: absolute;
-    right: 20px;
-    top: 10px;
-    z-index: 1;
-`
 
 const Wrapper = styled.div`
     display: flex;
@@ -53,11 +44,9 @@ export default function Columns({ children, title }) {
     return (
         <>
             <Wrapper>
-                <Lang />
                 <Left>{first}</Left>
                 <Right>{second}</Right>
             </Wrapper>
-            <Footer />
         </>
     )
 }

--- a/src/layout/Default/Default.tsx
+++ b/src/layout/Default/Default.tsx
@@ -4,7 +4,6 @@ import { SCREEN } from '../../styles/theme'
 import useDocumentTitle from '../../hooks/useDocumentTitle'
 import useDetectMobileOrTablet from '../../hooks/useDetectMobileOrTablet'
 import Header from '../../components/Header/Header'
-import Footer from '../../components/Footer/Footer'
 import BaseLang from '../../components/Lang/Lang'
 
 const Lang = styled(BaseLang)`
@@ -91,7 +90,6 @@ export default function Default({ children, title }: DefaultProps) {
             <Body>
                 <Container>{children}</Container>
             </Body>
-            {!isMobile && <Footer />}
         </Wrapper>
     )
 }

--- a/src/pages/Home/EmulatorLogin.tsx
+++ b/src/pages/Home/EmulatorLogin.tsx
@@ -4,8 +4,16 @@ import { Link } from 'react-router-dom'
 import { TEST_ACCOUNTS } from '../../constants'
 import { signInEmulatorEmailPassword } from '../../utils/emulators'
 import { useHistory } from 'react-router-dom'
+import styled from 'styled-components'
 
 const { paidUser, unpaidUser, overQuotaUser } = TEST_ACCOUNTS
+
+const StyledEmulatorLogin = styled.div`
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    z-index: 1;
+`
 
 export const EmulatorLogin = ({ authInstance, token }) => {
     const history = useHistory()
@@ -24,7 +32,7 @@ export const EmulatorLogin = ({ authInstance, token }) => {
         }
     }
     return (
-        <>
+        <StyledEmulatorLogin>
             <span>Emulator Signin: </span>
             <Button onClick={() => authInstance.signInAnonymously()}>
                 Anonymous
@@ -54,6 +62,6 @@ export const EmulatorLogin = ({ authInstance, token }) => {
                 OverQuota
             </Button>
             <Link to="premium-video">Go to Premium Video</Link>
-        </>
+        </StyledEmulatorLogin>
     )
 }

--- a/src/pages/VideoCall/VideoCall.tsx
+++ b/src/pages/VideoCall/VideoCall.tsx
@@ -6,7 +6,6 @@ import dailyCssText from './dailyCssText'
 import { CallContainer } from './VideoCallComponents'
 import Fullscreen from '../../components/Fullscreen/Fullscreen'
 import sendCallLogs from '../../actions/sendCallLogs'
-import Footer from '../../components/Footer/Footer'
 import { hideSupport, setVideoCallExited } from '../../utils/support'
 import Controls from './Controls'
 import VideoCallFrame from './VideoCallFrame'
@@ -183,8 +182,6 @@ const VideoCallPage = () => {
             {error && (
                 <ErrorDialog error={error} onHide={() => setError(null)} />
             )}
-
-            {leftCallFrame && <Footer />}
         </>
     )
 }

--- a/src/pages/VideoCall/VideoCallPrecheck.tsx
+++ b/src/pages/VideoCall/VideoCallPrecheck.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react'
 import CapabilitiesDialog from './permissions/CapabilitiesDialog'
 import VideoCallPage from './VideoCall'
-import Footer from '../../components/Footer/Footer'
 import { CallContainer } from './VideoCallComponents'
 
 const VideoCallPrecheck = () => {
@@ -18,8 +17,6 @@ const VideoCallPrecheck = () => {
                 onGranted={() => setCheckPass(true)}
                 onSkip={() => setCheckPass(true)}
             />
-
-            <Footer />
         </>
     )
 }


### PR DESCRIPTION
- remove footer from all pages
- move lang picker into the `NavigationDrawer` only
- replace `react-bootstrap` component `Navbar` with `AppBar` from `material-ui`
- add missing footer entries into `SwipeableTemporaryDrawer`

Fix #363

### To do in separate issues
- [ ] NewsletterModal opening needs being handled a different way
- [ ] Replace "default" menu entries icons
- [ ] Style links menu elements
- [ ] Fix menu logo (large screen, otherwise it seems fine)
- [ ] Place logo with longline into `AppBar`