### PR TITLE
Set correct room password & join room fixes

### DIFF
--- a/src/actions/getJwtToken.ts
+++ b/src/actions/getJwtToken.ts
@@ -7,19 +7,23 @@ const RETRY = {
     interval: 300,
 }
 
+async function sleep(intervalMillis: number) {
+    return new Promise((resolve) => {
+        setTimeout(function () {
+            resolve(true)
+        }, intervalMillis)
+    })
+}
+
 async function tryAtMost(promise, maxRetries, retryInterval) {
     let retriesNumber = 0
     while (retriesNumber <= maxRetries) {
         try {
+            retriesNumber++
             const result = await promise
             return result
         } catch (err) {
-            retriesNumber++
-            await new Promise((resolve) => {
-                setTimeout(function () {
-                    resolve(true)
-                }, retryInterval)
-            })
+            await sleep(RETRY.interval + RETRY.number ** 1.3)
         }
     }
 
@@ -33,7 +37,7 @@ export const getJwtToken = async (uid: UID): Promise<JWTToken> => {
         })
 
         /*
-            tryAtMost is needed because before a token can exist, firebase functions hook
+            tryAtMost is needed because before a token can exist, Firebase user create trigger
             need to successfully complete execution. Since this call is made right after login,
             the hook might have not finished executing yet
         */

--- a/src/actions/getJwtToken.ts
+++ b/src/actions/getJwtToken.ts
@@ -2,11 +2,46 @@ import { functions } from '../firebase/firebase'
 import { UID } from '../../types/uid'
 import { JWTToken } from '../../types/JWT'
 
+const RETRY = {
+    number: 4,
+    interval: 300,
+}
+
+async function tryAtMost(promise, maxRetries, retryInterval) {
+    let retriesNumber = 0
+    while (retriesNumber <= maxRetries) {
+        try {
+            const result = await promise
+            return result
+        } catch (err) {
+            retriesNumber++
+            await new Promise((resolve) => {
+                setTimeout(function () {
+                    resolve(true)
+                }, retryInterval)
+            })
+        }
+    }
+
+    throw new Error()
+}
+
 export const getJwtToken = async (uid: UID): Promise<JWTToken> => {
     try {
-        const result = await functions.getToken({
+        const getTokenPromise = functions.getToken({
             uid,
         })
+
+        /*
+            tryAtMost is needed because before a token can exist, firebase functions hook
+            need to successfully complete execution. Since this call is made right after login,
+            the hook might have not finished executing yet
+        */
+        const result = await tryAtMost(
+            getTokenPromise,
+            RETRY.number,
+            RETRY.interval
+        )
 
         const jwtToken: JWTToken = result?.data.token
         if (!jwtToken) {

--- a/src/components/App/AppBar/AppBar.tsx
+++ b/src/components/App/AppBar/AppBar.tsx
@@ -7,6 +7,11 @@ import Button from '@material-ui/core/Button'
 import SwipeableTemporaryDrawer from '../../SwipeableTemporaryDrawer/SwipeableTemporaryDrawer'
 import styled from 'styled-components'
 import { useTranslation } from 'react-i18next'
+import { useDispatch, useSelector } from 'react-redux'
+import { showLoginModal } from '../../LoginModal/loginModalActions'
+import { signOut } from '../../../actions/userActions'
+import { selectToken } from '../userSelector'
+import { authInstance } from '../../../firebase/firebase'
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -29,9 +34,11 @@ const WhiteAppBar = styled.div`
     }
 `
 
-export default function AppBar() {
+const AppBar = () => {
     const classes = useStyles()
+    const hasToken = useSelector(selectToken)
     const { t } = useTranslation('common')
+    const dispatch = useDispatch()
 
     return (
         <div className={classes.root}>
@@ -47,9 +54,21 @@ export default function AppBar() {
                         <Button color="primary">
                             {t('appBar.joinVisioButton')}
                         </Button>
-                        <Button color="primary">
-                            {t('appBar.loginButton')}
-                        </Button>
+                        {hasToken ? (
+                            <Button
+                                onClick={() => {
+                                    dispatch(signOut())
+                                }}>
+                                Sign out
+                            </Button>
+                        ) : (
+                            <Button
+                                onClick={() => dispatch(showLoginModal())}
+                                color="primary">
+                                {t('appBar.loginButton')}
+                            </Button>
+                        )}
+
                         <SwipeableTemporaryDrawer />
                     </Toolbar>
                 </MaterialAppBar>
@@ -57,3 +76,5 @@ export default function AppBar() {
         </div>
     )
 }
+
+export default AppBar

--- a/src/components/App/AppBar/AppBar.tsx
+++ b/src/components/App/AppBar/AppBar.tsx
@@ -10,8 +10,7 @@ import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { showLoginModal } from '../../LoginModal/loginModalActions'
 import { signOut } from '../../../actions/userActions'
-import { selectToken } from '../userSelector'
-import { authInstance } from '../../../firebase/firebase'
+import { selectToken, selectUser } from '../userSelector'
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -37,6 +36,7 @@ const WhiteAppBar = styled.div`
 const AppBar = () => {
     const classes = useStyles()
     const hasToken = useSelector(selectToken)
+    const user = useSelector(selectUser)
     const { t } = useTranslation('common')
     const dispatch = useDispatch()
 
@@ -54,7 +54,7 @@ const AppBar = () => {
                         <Button color="primary">
                             {t('appBar.joinVisioButton')}
                         </Button>
-                        {hasToken ? (
+                        {hasToken && !user.isAnonymous ? (
                             <Button
                                 onClick={() => {
                                     dispatch(signOut())

--- a/src/components/App/AuthStateChangedListener/AuthStateChangedListener.tsx
+++ b/src/components/App/AuthStateChangedListener/AuthStateChangedListener.tsx
@@ -4,12 +4,11 @@ import { didSignin } from '../../../actions/userActions'
 import { useDispatch } from 'react-redux'
 import { hideLoginModal } from '../../LoginModal/loginModalActions'
 
-const LoginState = () => {
+const AuthStateChangedListener = () => {
     const dispatch = useDispatch()
 
     useEffect(() => {
         return authInstance.onAuthStateChanged((user) => {
-            console.log('Auth state changed: ', user)
             dispatch(didSignin(user))
             dispatch(hideLoginModal())
         })
@@ -18,4 +17,4 @@ const LoginState = () => {
     return <></>
 }
 
-export default LoginState
+export default AuthStateChangedListener

--- a/src/components/App/LoginState/LoginState.tsx
+++ b/src/components/App/LoginState/LoginState.tsx
@@ -1,0 +1,21 @@
+import React, { useEffect } from 'react'
+import { authInstance } from '../../../firebase/firebase'
+import { didSignin } from '../../../actions/userActions'
+import { useDispatch } from 'react-redux'
+import { hideLoginModal } from '../../LoginModal/loginModalActions'
+
+const LoginState = () => {
+    const dispatch = useDispatch()
+
+    useEffect(() => {
+        return authInstance.onAuthStateChanged((user) => {
+            console.log('Auth state changed: ', user)
+            dispatch(didSignin(user))
+            dispatch(hideLoginModal())
+        })
+    }, [dispatch])
+
+    return <></>
+}
+
+export default LoginState

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components'
 import Snackbar from './Snackbar/Snackbar'
 import { PushNotifications } from './PushNotifications/PushNotifications'
 import LoginModal from '../LoginModal/LoginModal'
-import LoginState from './LoginState/LoginState'
+import AuthStateChangedListener from './AuthStateChangedListener/AuthStateChangedListener'
 declare global {
     interface Window {
         iv: any
@@ -50,7 +50,7 @@ const App = () => {
         <IonApp className="App">
             <PushNotifications />
             <Snackbar />
-            <LoginState />
+            <AuthStateChangedListener />
             <LoginModal />
             <IonReactRouter>
                 <IonHeader id="topbar">

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -4,11 +4,12 @@ import { gdprHandler } from '../../utils/gdpr'
 import Router from './Router'
 import { IonApp, IonHeader } from '@ionic/react'
 import { IonReactRouter } from '@ionic/react-router'
-import Login from '../Login'
 import AppBar from './AppBar/AppBar'
 import styled from 'styled-components'
 import Snackbar from './Snackbar/Snackbar'
 import { PushNotifications } from './PushNotifications/PushNotifications'
+import LoginModal from '../LoginModal/LoginModal'
+import LoginState from './LoginState/LoginState'
 declare global {
     interface Window {
         iv: any
@@ -49,8 +50,8 @@ const App = () => {
         <IonApp className="App">
             <PushNotifications />
             <Snackbar />
-
-            <Login />
+            <LoginState />
+            <LoginModal />
             <IonReactRouter>
                 <IonHeader id="topbar">
                     <AppBar />

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -8,7 +8,7 @@ import {
     selectToken,
     isLoading as isLoadingSelector,
 } from '../App/userSelector'
-import { useDispatch, useSelector } from 'react-redux'
+import { useSelector } from 'react-redux'
 
 export const isUsingEmulator = () => {
     return process.env.FIREBASE_AUTH_EMULATOR_HOST

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -1,16 +1,18 @@
-import React, { useEffect } from 'react'
-import { authInstance, firebaseAuth } from '../firebase/firebase'
+import React from 'react'
+import { authInstance, firebaseAuth } from '../../firebase/firebase'
 import { StyledFirebaseAuth } from 'react-firebaseui'
-import { Button } from 'react-bootstrap'
-import { didSignin, signOut } from '../actions/userActions'
-import { EMULATORS } from '../constants'
+import { EMULATORS } from '../../constants'
 import { auth as firebaseuiAuth } from 'firebaseui'
-import { isAuthEmulatorEnabled } from '../utils/emulators'
+import { isAuthEmulatorEnabled } from '../../utils/emulators'
 import {
     selectToken,
     isLoading as isLoadingSelector,
-} from '../components/App/userSelector'
+} from '../App/userSelector'
 import { useDispatch, useSelector } from 'react-redux'
+
+export const isUsingEmulator = () => {
+    return process.env.FIREBASE_AUTH_EMULATOR_HOST
+}
 
 const uiConfig = {
     // Popup signin flow rather than redirect flow.
@@ -26,6 +28,7 @@ const uiConfig = {
     ],
     callbacks: {
         signInSuccessWithAuthResult: ({ user }) => {
+            console.log('signInSuccessWithAuthResult called')
             return !user.isAnonymous
         },
         signInFailure: async function (error) {
@@ -37,47 +40,24 @@ const uiConfig = {
 const Login = () => {
     const hasToken = useSelector(selectToken)
     const isLoading = useSelector(isLoadingSelector)
-    const dispatch = useDispatch()
 
     if (isAuthEmulatorEnabled()) {
         authInstance.useEmulator(EMULATORS.hosts.auth)
     }
-
-    useEffect(() => {
-        return authInstance.onAuthStateChanged((user) => {
-            dispatch(didSignin(user))
-        })
-    }, [dispatch])
 
     if (isLoading) {
         //todo loading
         return <div>...loading</div>
     }
 
-    //temporary ui
     return (
-        <div
-            style={{
-                position: 'absolute',
-                left: 0,
-                background: '#4444FF55',
-                zIndex: 50,
-            }}>
+        <div>
             {!hasToken && (
                 <StyledFirebaseAuth
                     uiConfig={uiConfig}
                     firebaseAuth={authInstance}
                 />
             )}
-            {hasToken && (
-                <Button
-                    onClick={() => {
-                        dispatch(signOut())
-                    }}>
-                    Sign out
-                </Button>
-            )}
-            Temporary LOGIN UI
         </div>
     )
 }

--- a/src/components/LoginModal/LoginModal.tsx
+++ b/src/components/LoginModal/LoginModal.tsx
@@ -31,36 +31,30 @@ export default function LoginModal() {
     }
 
     return (
-        <>
-            <Modal
-                isOpened={isDisplayed}
-                onClose={() => {
-                    dispatch(hideLoginModal())
-                }}>
-                <Login />
-                {isAuthEmulatorEnabled() && (
-                    <>
-                        <Button
-                            onClick={() =>
-                                signInWithEmailAndPassword(paidUser)
-                            }>
-                            Paid
-                        </Button>
-                        <Button
-                            onClick={() =>
-                                signInWithEmailAndPassword(unpaidUser)
-                            }>
-                            Unpaid
-                        </Button>
-                        <Button
-                            onClick={() =>
-                                signInWithEmailAndPassword(overQuotaUser)
-                            }>
-                            OverQuota
-                        </Button>
-                    </>
-                )}
-            </Modal>
-        </>
+        <Modal
+            isOpened={isDisplayed}
+            onClose={() => {
+                dispatch(hideLoginModal())
+            }}>
+            <Login />
+            {isAuthEmulatorEnabled() && (
+                <>
+                    <Button
+                        onClick={() => signInWithEmailAndPassword(paidUser)}>
+                        Paid
+                    </Button>
+                    <Button
+                        onClick={() => signInWithEmailAndPassword(unpaidUser)}>
+                        Unpaid
+                    </Button>
+                    <Button
+                        onClick={() =>
+                            signInWithEmailAndPassword(overQuotaUser)
+                        }>
+                        OverQuota
+                    </Button>
+                </>
+            )}
+        </Modal>
     )
 }

--- a/src/components/LoginModal/LoginModal.tsx
+++ b/src/components/LoginModal/LoginModal.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import { selectLoginModal } from './loginModalSelector'
+import { hideLoginModal } from './loginModalActions'
+import Login from '../Login/Login'
+import Modal from '../Modal/Modal'
+import Button from '@material-ui/core/Button'
+import {
+    isAuthEmulatorEnabled,
+    signInEmulatorEmailPassword,
+} from '../../utils/emulators'
+import { TEST_ACCOUNTS } from '../../constants'
+import { authInstance } from '../../firebase/firebase'
+const { paidUser, unpaidUser, overQuotaUser } = TEST_ACCOUNTS
+
+export default function LoginModal() {
+    const { isDisplayed } = useSelector(selectLoginModal)
+    const dispatch = useDispatch()
+    const signInWithEmailAndPassword = async ({ email, password }) => {
+        try {
+            const user = await signInEmulatorEmailPassword(
+                authInstance,
+                email,
+                password
+            )
+            console.log('Signed In with user: ', user)
+        } catch (error) {
+            const { code, message } = error
+            console.log(`Error email auth: ${code}, message: ${message}`)
+        }
+    }
+
+    return (
+        <>
+            <Modal
+                isOpened={isDisplayed}
+                onClose={() => {
+                    dispatch(hideLoginModal())
+                }}>
+                <Login />
+                {isAuthEmulatorEnabled() && (
+                    <>
+                        <Button
+                            onClick={() =>
+                                signInWithEmailAndPassword(paidUser)
+                            }>
+                            Paid
+                        </Button>
+                        <Button
+                            onClick={() =>
+                                signInWithEmailAndPassword(unpaidUser)
+                            }>
+                            Unpaid
+                        </Button>
+                        <Button
+                            onClick={() =>
+                                signInWithEmailAndPassword(overQuotaUser)
+                            }>
+                            OverQuota
+                        </Button>
+                    </>
+                )}
+            </Modal>
+        </>
+    )
+}

--- a/src/components/LoginModal/loginModalActionTypes.ts
+++ b/src/components/LoginModal/loginModalActionTypes.ts
@@ -1,0 +1,14 @@
+export const SHOW_LOGIN_MODAL = 'SHOW_LOGIN_MODAL'
+export const HIDE_LOGIN_MODAL = 'HIDE_LOGIN_MODAL'
+
+interface ShowLoginModalAction {
+    type: typeof SHOW_LOGIN_MODAL
+    payload: {}
+}
+
+interface HideLoginModalAction {
+    type: typeof HIDE_LOGIN_MODAL
+    payload: {}
+}
+
+export type LoginModalActionTypes = ShowLoginModalAction | HideLoginModalAction

--- a/src/components/LoginModal/loginModalActions.ts
+++ b/src/components/LoginModal/loginModalActions.ts
@@ -1,0 +1,15 @@
+import {
+    HIDE_LOGIN_MODAL,
+    SHOW_LOGIN_MODAL,
+    LoginModalActionTypes,
+} from './loginModalActionTypes'
+
+export const showLoginModal = (): LoginModalActionTypes => ({
+    type: SHOW_LOGIN_MODAL,
+    payload: {},
+})
+
+export const hideLoginModal = (): LoginModalActionTypes => ({
+    type: HIDE_LOGIN_MODAL,
+    payload: {},
+})

--- a/src/components/LoginModal/loginModalReducer.ts
+++ b/src/components/LoginModal/loginModalReducer.ts
@@ -1,0 +1,25 @@
+import produce, { Draft } from 'immer'
+import { HIDE_LOGIN_MODAL, SHOW_LOGIN_MODAL } from './loginModalActionTypes'
+import { LoginModalState } from './loginModalSelector'
+
+const initialState = {
+    isDisplayed: false,
+}
+
+export const loginModalReducer = produce(
+    (draft: Draft<LoginModalState>, { type, payload }) => {
+        switch (type) {
+            case HIDE_LOGIN_MODAL:
+                return {
+                    ...draft,
+                    isDisplayed: false,
+                }
+            case SHOW_LOGIN_MODAL:
+                return {
+                    ...draft,
+                    isDisplayed: true,
+                }
+        }
+    },
+    initialState
+)

--- a/src/components/LoginModal/loginModalReducer.ts
+++ b/src/components/LoginModal/loginModalReducer.ts
@@ -10,15 +10,11 @@ export const loginModalReducer = produce(
     (draft: Draft<LoginModalState>, { type, payload }) => {
         switch (type) {
             case HIDE_LOGIN_MODAL:
-                return {
-                    ...draft,
-                    isDisplayed: false,
-                }
+                draft.isDisplayed = false
+                break
             case SHOW_LOGIN_MODAL:
-                return {
-                    ...draft,
-                    isDisplayed: true,
-                }
+                draft.isDisplayed = true
+                break
         }
     },
     initialState

--- a/src/components/LoginModal/loginModalSelector.ts
+++ b/src/components/LoginModal/loginModalSelector.ts
@@ -2,7 +2,7 @@ import { AppState } from '../../reducers/rootReducer'
 import { createSelector } from 'reselect'
 
 export interface LoginModalState {
-    isDisplayed: false
+    isDisplayed: boolean
 }
 
 export const selectLoginModal = createSelector(

--- a/src/components/LoginModal/loginModalSelector.ts
+++ b/src/components/LoginModal/loginModalSelector.ts
@@ -1,0 +1,11 @@
+import { AppState } from '../../reducers/rootReducer'
+import { createSelector } from 'reselect'
+
+export interface LoginModalState {
+    isDisplayed: false
+}
+
+export const selectLoginModal = createSelector(
+    (state: AppState) => state.loginModal,
+    (loginModal: LoginModalState) => loginModal
+)

--- a/src/pages/Admin/Dashboard.tsx
+++ b/src/pages/Admin/Dashboard.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { IonContent } from '@ionic/react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
+import { Button } from '@material-ui/core'
+import { useHistory } from 'react-router-dom'
 
 const InformationBlock = styled.div`
     height: 100%;
@@ -16,10 +18,19 @@ const InformationBlock = styled.div`
 
 export default function Dashboard() {
     const { t } = useTranslation('admin')
+    const history = useHistory()
+    const startPremiumVideoCall = () => {
+        history.push('/premium-video/room/testRoom?passcode=admin')
+    }
 
     return (
         <IonContent style={{ '--background': 'white' }}>
-            <InformationBlock>{t('dashboard.welcome')}</InformationBlock>
+            <InformationBlock>
+                {t('dashboard.welcome')}
+                <Button onClick={() => startPremiumVideoCall()}>
+                    Start Call
+                </Button>
+            </InformationBlock>
         </IonContent>
     )
 }

--- a/src/pages/Home/EmulatorLogin.tsx
+++ b/src/pages/Home/EmulatorLogin.tsx
@@ -1,12 +1,7 @@
 import React from 'react'
 import { Button } from 'react-bootstrap'
-import { Link } from 'react-router-dom'
-import { TEST_ACCOUNTS } from '../../constants'
-import { signInEmulatorEmailPassword } from '../../utils/emulators'
 import { useHistory } from 'react-router-dom'
 import styled from 'styled-components'
-
-const { paidUser, unpaidUser, overQuotaUser } = TEST_ACCOUNTS
 
 const StyledEmulatorLogin = styled.div`
     position: absolute;
@@ -15,53 +10,16 @@ const StyledEmulatorLogin = styled.div`
     z-index: 1;
 `
 
-export const EmulatorLogin = ({ authInstance, token }) => {
+export const EmulatorLogin = ({ authInstance }) => {
     const history = useHistory()
     const isAnonymous = authInstance.currentUser?.isAnonymous
-    const signInWithEmailAndPassword = async ({ email, password }) => {
-        try {
-            const user = await signInEmulatorEmailPassword(
-                authInstance,
-                email,
-                password
-            )
-            console.log('Signed In with user: ', user)
-        } catch (error) {
-            const { code, message } = error
-            console.log(`Error email auth: ${code}, message: ${message}`)
-        }
-    }
+
     return (
         <StyledEmulatorLogin>
             <span>Emulator Signin: </span>
-            <Button onClick={() => authInstance.signInAnonymously()}>
-                Anonymous
-            </Button>
-            {token && (
-                <>
-                    {!isAnonymous && (
-                        <Button onClick={() => history.push('/admin')}>
-                            Admin
-                        </Button>
-                    )}
-                    <Button
-                        onClick={() => {
-                            authInstance.signOut()
-                        }}>
-                        Sign out
-                    </Button>
-                </>
+            {!isAnonymous && (
+                <Button onClick={() => history.push('/admin')}>Admin</Button>
             )}
-            <Button onClick={() => signInWithEmailAndPassword(paidUser)}>
-                Paid
-            </Button>
-            <Button onClick={() => signInWithEmailAndPassword(unpaidUser)}>
-                Unpaid
-            </Button>
-            <Button onClick={() => signInWithEmailAndPassword(overQuotaUser)}>
-                OverQuota
-            </Button>
-            <Link to="premium-video">Go to Premium Video</Link>
         </StyledEmulatorLogin>
     )
 }

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -19,8 +19,6 @@ import { IonContent } from '@ionic/react'
 import * as LocalStorage from '../../services/local-storage'
 import { authInstance } from '../../firebase/firebase'
 import { isAuthEmulatorEnabled } from '../../utils/emulators'
-import { selectToken } from '../../components/App/userSelector'
-import { useSelector } from 'react-redux'
 import { EmulatorLogin } from './EmulatorLogin'
 
 const DataMentions = styled.div`
@@ -56,7 +54,6 @@ const KnowMoreMobile = styled.p`
 
 export default function Home() {
     const { t } = useTranslation(['home', 'common'])
-    const token = useSelector(selectToken)
     const [videoCallId, setVideoCallId] = useState()
     const [error, setError] = useState()
     const isMobile = useDetectMobileOrTablet()

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -86,7 +86,7 @@ export default function Home() {
     return (
         <IonContent>
             {isAuthEmulatorEnabled() && (
-                <EmulatorLogin authInstance={authInstance} token={token} />
+                <EmulatorLogin authInstance={authInstance} />
             )}
 
             {!isMobile ? (

--- a/src/pages/PremiumVideoCall/components/PreJoinScreens/DeviceSelectionScreen/DeviceSelectionScreen.tsx
+++ b/src/pages/PremiumVideoCall/components/PreJoinScreens/DeviceSelectionScreen/DeviceSelectionScreen.tsx
@@ -20,7 +20,6 @@ import ToggleAudioButton from '../../Buttons/ToggleAudioButton/ToggleAudioButton
 import ToggleVideoButton from '../../Buttons/ToggleVideoButton/ToggleVideoButton'
 import { useAppState } from '../../../state'
 import useVideoContext from '../../../hooks/useVideoContext/useVideoContext'
-import { Api } from '../../../../../services/api'
 import { selectToken } from '../../../../../components/App/userSelector'
 import { useSelector, useDispatch } from 'react-redux'
 import { RoomId } from '../../../../../../types/Room'
@@ -83,7 +82,7 @@ export default function DeviceSelectionScreen({
     setStep,
 }: DeviceSelectionScreenProps) {
     const classes = useStyles()
-    const { isFetching } = useAppState()
+    const { isFetching, getTwilioVideoToken } = useAppState()
     const token = useSelector(selectToken)
     const dispatch = useDispatch()
     const { connect, isAcquiringLocalTracks, isConnecting } = useVideoContext()
@@ -93,12 +92,20 @@ export default function DeviceSelectionScreen({
 
     const handleJoin = async () => {
         setIsLoading(true)
-        const api = new Api(token)
-        const { jwtAccessToken } = await api.joinRoom(roomId, 'test-password') // TODO pass the password variable
-        dispatch(actions.setRoomId(roomId))
-        dispatch(actions.setHostName(name))
-        connect(jwtAccessToken, roomId)
-        setIsLoading(false)
+        try {
+            const twilioVideoToken = await getTwilioVideoToken(
+                token,
+                roomId,
+                name
+            )
+
+            dispatch(actions.setRoomId(roomId))
+            dispatch(actions.setHostName(name))
+            connect(twilioVideoToken, roomId)
+            setIsLoading(false)
+        } catch (err) {
+            setIsLoading(false)
+        }
     }
 
     return (

--- a/src/pages/PremiumVideoCall/state/usePasscodeAuth/usePasscodeAuth.ts
+++ b/src/pages/PremiumVideoCall/state/usePasscodeAuth/usePasscodeAuth.ts
@@ -75,7 +75,7 @@ export default function usePasscodeAuth() {
             ) => {
                 const roomPassword = user!.passcode
                 const passwordSpecified =
-                    !instantVisioUser.isAnonymous && roomPassword == 'admin'
+                    !instantVisioUser.isAnonymous && roomPassword === 'admin'
                         ? null
                         : roomPassword
                 const token = await fetchTwilioVideoToken(
@@ -94,7 +94,7 @@ export default function usePasscodeAuth() {
                 participantName
             )
         },
-        [user]
+        [user, instantVisioUser]
     )
 
     useEffect(() => {

--- a/src/pages/PremiumVideoCall/state/usePasscodeAuth/usePasscodeAuth.ts
+++ b/src/pages/PremiumVideoCall/state/usePasscodeAuth/usePasscodeAuth.ts
@@ -9,6 +9,8 @@ import { RoomType } from '../../types'
 import { Api } from '../../../../services/api'
 import { JWTToken } from '../../../../../types/JWT'
 import { RoomId } from '../../../../../types/Room'
+import { selectUser } from '../../../../components/App/userSelector'
+import { useSelector } from 'react-redux'
 
 export function getPasscode() {
     const match = window.location.search.match(/passcode=(.*)&?/)
@@ -21,10 +23,15 @@ export function getPasscode() {
 export async function fetchTwilioVideoToken(
     instantVisioToken: JWTToken,
     roomId: RoomId,
-    password: string
+    participantName: string,
+    password: string | null
 ) {
     const api = new Api(instantVisioToken)
-    const { jwtAccessToken } = await api.joinRoom(roomId, password)
+    const { jwtAccessToken } = await api.joinRoom(
+        roomId,
+        participantName,
+        password
+    )
     return jwtAccessToken
 }
 
@@ -45,6 +52,7 @@ export function getErrorMessage(message: string) {
 
 export default function usePasscodeAuth() {
     const history = useHistory()
+    const instantVisioUser = useSelector(selectUser)
 
     const [user, setUser] = useState<{
         displayName: undefined
@@ -55,22 +63,36 @@ export default function usePasscodeAuth() {
     const [roomType, setRoomType] = useState<RoomType>()
 
     const getTwilioVideoToken = useCallback(
-        (instantVisioToken: string, roomId: RoomId) => {
+        (
+            instantVisioToken: string,
+            roomId: RoomId,
+            participantName: string
+        ) => {
             const fetchTokenAndSetRoomType = async (
                 instantVisioToken,
-                roomId
+                roomId,
+                participantName
             ) => {
+                const roomPassword = user!.passcode
+                const passwordSpecified =
+                    !instantVisioUser.isAnonymous && roomPassword == 'admin'
+                        ? null
+                        : roomPassword
                 const token = await fetchTwilioVideoToken(
                     instantVisioToken,
                     roomId,
-                    user!.passcode
+                    participantName,
+                    passwordSpecified
                 )
-
                 setRoomType('group')
                 return token as string
             }
 
-            return fetchTokenAndSetRoomType(instantVisioToken, roomId)
+            return fetchTokenAndSetRoomType(
+                instantVisioToken,
+                roomId,
+                participantName
+            )
         },
         [user]
     )
@@ -87,7 +109,9 @@ export default function usePasscodeAuth() {
                         history.replace(window.location.pathname)
                     }
                 })
-                .then(() => setIsAuthReady(true))
+                .then(() => {
+                    setIsAuthReady(true)
+                })
         } else {
             setIsAuthReady(true)
         }

--- a/src/reducers/rootReducer.ts
+++ b/src/reducers/rootReducer.ts
@@ -2,18 +2,22 @@ import { combineReducers } from 'redux'
 import { snackbarReducer } from '../components/App/Snackbar/snackbarReducer'
 import { SnackbarState } from '../components/App/Snackbar/snackbarSelector'
 import { userReducer, UserState } from '../components/App/userReducer'
+import { LoginModalState } from '../components/LoginModal/loginModalSelector'
 import { roomReducer, RoomState } from '../pages/PremiumVideoCall/roomReducer'
+import { loginModalReducer } from '../components/LoginModal/loginModalReducer'
 
 export interface AppState {
     user: UserState
     room: RoomState
     snackbar: SnackbarState
+    loginModal: LoginModalState
 }
 
 const rootReducer = combineReducers({
     user: userReducer,
     room: roomReducer,
     snackbar: snackbarReducer,
+    loginModal: loginModalReducer,
 })
 
 export default rootReducer

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -19,9 +19,20 @@ export class Api {
 
     async joinRoom(
         roomId: RoomId,
-        password: string
+        participantName: string,
+        password: string | null
     ): Promise<JoinRoomResponse> {
-        return this.post(`/rooms/${roomId}/join`, { password })
+        try {
+            const joinResponse = await this.post(`/rooms/${roomId}/join`, {
+                participantName,
+                password,
+            })
+            return joinResponse
+        } catch (err) {
+            throw new Error(
+                'Connection error, maybe the room has not been created yet. Pls try again later'
+            )
+        }
     }
 
     async inviteParticipants(
@@ -44,6 +55,10 @@ export class Api {
             },
             body: data ? JSON.stringify(data) : null,
         })
+
+        if (response.status !== 200 && response.status !== 204) {
+            throw new Error(`Post request failed: ${response.statusText}`)
+        }
         return response.json()
     }
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -22,17 +22,10 @@ export class Api {
         participantName: string,
         password: string | null
     ): Promise<JoinRoomResponse> {
-        try {
-            const joinResponse = await this.post(`/rooms/${roomId}/join`, {
-                participantName,
-                password,
-            })
-            return joinResponse
-        } catch (err) {
-            throw new Error(
-                'Connection error, maybe the room has not been created yet. Pls try again later'
-            )
-        }
+        return this.post(`/rooms/${roomId}/join`, {
+            participantName,
+            password,
+        })
     }
 
     async inviteParticipants(
@@ -57,7 +50,7 @@ export class Api {
         })
 
         if (response.status !== 200 && response.status !== 204) {
-            throw new Error(`Post request failed: ${response.statusText}`)
+            throw new Error(response.statusText)
         }
         return response.json()
     }


### PR DESCRIPTION
- Set correct room password (previously hard-coded) ->
workaround to handle the admin user navigating to `PremiumVideo` page: from the Dashboard we send him to `/premium-video/room/${roomId}?passcode=admin` since the passcode is required by the original code. When the passcode is `admin` although, it is not gonna be sent to `joinRoom` endpoint, so that a new password will be created on API side
- Hide sign out button for anonymous users
- retry `getJwtToken` (explained in code comment)
- move temporary login UI into a Modal window. Show the modal on login button click
- Add `LoginState` component that subscribes to auth state changes (otherwise the subscription won't occur, since `Login` component is now within a Modal window)
- pave the way to remove `EmulatorLogin` -> emulator login helper buttons moved into `LoginModal`
- handle join room error: "Token must be a string" was displayed
- send `participantName` to `joinRoom` endpoint

Fix #345