### PR TITLE
WebApp fixes & enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5173,21 +5173,11 @@
             "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
         },
         "axios": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-            "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+            "version": "0.21.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+            "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
             "requires": {
-                "follow-redirects": "1.5.10"
-            },
-            "dependencies": {
-                "follow-redirects": {
-                    "version": "1.5.10",
-                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-                    "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-                    "requires": {
-                        "debug": "=3.1.0"
-                    }
-                }
+                "follow-redirects": "^1.10.0"
             }
         },
         "axobject-query": {
@@ -5645,11 +5635,6 @@
             "requires": {
                 "tweetnacl": "^0.14.3"
             }
-        },
-        "beauty-stars": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/beauty-stars/-/beauty-stars-1.1.0.tgz",
-            "integrity": "sha512-h2debWueuXWv3MR3bwGCgqxzBv8bHyf8DagppWN4XAweJ6rhdtyl0uxosiOg6ODyDefYTv8TBcgSe4B3n0THuA=="
         },
         "big-integer": {
             "version": "1.6.48",
@@ -22324,6 +22309,22 @@
                 "xmlbuilder": "^13.0.2"
             },
             "dependencies": {
+                "axios": {
+                    "version": "0.19.2",
+                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+                    "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+                    "requires": {
+                        "follow-redirects": "1.5.10"
+                    }
+                },
+                "follow-redirects": {
+                    "version": "1.5.10",
+                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+                    "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+                    "requires": {
+                        "debug": "=3.1.0"
+                    }
+                },
                 "lodash": {
                     "version": "4.17.20",
                     "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "@types/react-router-dom": "^5.1.3",
         "@types/styled-components": "^5.1.4",
         "@types/twilio-video": "^2.7.0",
+        "axios": "^0.21.1",
         "bootstrap": "^4.4.1",
         "classnames": "^2.2.6",
         "color": "^3.1.2",

--- a/public/locales/en/premium-video.json
+++ b/public/locales/en/premium-video.json
@@ -1,0 +1,5 @@
+{
+    "errors": {
+        "missing-password": "You need to provide a password within the link in order to join a room"
+    }
+}

--- a/public/locales/fr/premium-video.json
+++ b/public/locales/fr/premium-video.json
@@ -1,0 +1,5 @@
+{
+    "errors": {
+        "missing-password": "Le lien pour joindre une Visio doit inclure un mot-de-passe"
+    }
+}

--- a/src/components/App/App.scss
+++ b/src/components/App/App.scss
@@ -1,44 +1,49 @@
 html body,
 html {
-  margin: 0;
-  font-family: 'Open Sans', sans-serif;
-  background-color: #323742;
-  height: 100%;
-  overflow-x: hidden;
-
-  & .btn {
-    background-color: #468ea0;
-    padding: 0.375rem 1.5rem;
-    font-size: 1rem;
-    text-transform: uppercase;
-  }
-  @keyframes loading {
-    100% {
-      transform: translateX(100%);
-    }
-  }
-
-  .loading {
-    position: relative;
-    overflow: hidden;
-
-    &::after {
-      display: block;
-      content: '';
-      position: absolute;
-      width: 100%;
-      height: 100%;
-      top: 0;
-      transform: translateX(-100%);
-      background: linear-gradient(90deg, transparent, rgba(255, 255, 255, .5), transparent);
-      animation: loading 1.2s infinite;
-    }
-  }
-
-  #root {
+    margin: 0;
+    font-family: 'Open Sans', sans-serif;
     background-color: #323742;
     height: 100%;
-  }
+    overflow-x: hidden;
+
+    & .btn {
+        background-color: #468ea0;
+        padding: 0.375rem 1.5rem;
+        font-size: 1rem;
+        text-transform: uppercase;
+    }
+    @keyframes loading {
+        100% {
+            transform: translateX(100%);
+        }
+    }
+
+    .loading {
+        position: relative;
+        overflow: hidden;
+
+        &::after {
+            display: block;
+            content: '';
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            top: 0;
+            transform: translateX(-100%);
+            background: linear-gradient(
+                90deg,
+                transparent,
+                rgba(255, 255, 255, 0.5),
+                transparent
+            );
+            animation: loading 1.2s infinite;
+        }
+    }
+
+    #root {
+        background-color: #323742;
+        height: 100%;
+    }
 }
 
 .App {
@@ -49,11 +54,11 @@ ion-content {
     --background: #323742;
 }
 
-@media screen and (max-width: 767px) {
-    ion-content {
-        --padding-top: 2.5rem;
-    }
+ion-content {
+    --padding-top: 5rem;
+}
 
+@media screen and (max-width: 767px) {
     ion-item {
         width: 100%;
     }
@@ -81,7 +86,13 @@ ion-content {
     }
 }
 
-@media screen and (max-width: 1179px) and (min-width:768px) {
+@media screen and (min-width: 1179px) {
+    ion-content {
+        --padding-top: 4rem;
+    }
+}
+
+@media screen and (max-width: 1179px) and (min-width: 768px) {
     .logo {
         &-link {
             width: 18%;

--- a/src/components/App/AppBar/AppBar.tsx
+++ b/src/components/App/AppBar/AppBar.tsx
@@ -11,6 +11,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { showLoginModal } from '../../LoginModal/loginModalActions'
 import { signOut } from '../../../actions/userActions'
 import { selectToken, selectUser } from '../userSelector'
+import { useHistory } from 'react-router-dom'
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -39,6 +40,8 @@ const AppBar = () => {
     const user = useSelector(selectUser)
     const { t } = useTranslation('common')
     const dispatch = useDispatch()
+    const history = useHistory()
+    const isPremiumUser = hasToken && !user.isAnonymous
 
     return (
         <div className={classes.root}>
@@ -54,10 +57,11 @@ const AppBar = () => {
                         <Button color="primary">
                             {t('appBar.joinVisioButton')}
                         </Button>
-                        {hasToken && !user.isAnonymous ? (
+                        {isPremiumUser ? (
                             <Button
                                 onClick={() => {
                                     dispatch(signOut())
+                                    history.replace('/')
                                 }}>
                                 Sign out
                             </Button>

--- a/src/components/App/AppBar/AppBar.tsx
+++ b/src/components/App/AppBar/AppBar.tsx
@@ -10,8 +10,8 @@ import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { showLoginModal } from '../../LoginModal/loginModalActions'
 import { signOut } from '../../../actions/userActions'
-import { selectToken, selectUser } from '../userSelector'
 import { useHistory } from 'react-router-dom'
+import { selectIsPremiumUser } from '../userSelector'
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -36,12 +36,10 @@ const WhiteAppBar = styled.div`
 
 const AppBar = () => {
     const classes = useStyles()
-    const hasToken = useSelector(selectToken)
-    const user = useSelector(selectUser)
+    const isPremiumUser = useSelector(selectIsPremiumUser)
     const { t } = useTranslation('common')
     const dispatch = useDispatch()
     const history = useHistory()
-    const isPremiumUser = hasToken && !user.isAnonymous
 
     return (
         <div className={classes.root}>

--- a/src/components/App/Router.tsx
+++ b/src/components/App/Router.tsx
@@ -22,6 +22,7 @@ import PermissionVideoAudio from '../../pages/PermissionVideoAudio/PermissionVid
 import ProtectedRoute from './ProtectedRoute'
 import { selectUser } from './userSelector'
 import { useSelector } from 'react-redux'
+import { IonContent } from '@ionic/react'
 
 const Dashboard = lazy(() => import('../../pages/Admin/Dashboard'))
 
@@ -31,63 +32,68 @@ const Router = () => {
 
     return (
         <IonRouterOutlet>
-            <Switch>
-                <Route path="/" exact component={Home} />
-                <Route
-                    path={`/${t('url.video-call')}/:videoName`}
-                    component={VideoCallPrecheck}
-                />
-                <Route
-                    path={`/${t('url.video-call')}`}
-                    component={JoinVideoCall}
-                />
-                <Route
-                    path={`/${t('url.legal-mentions')}`}
-                    exact
-                    component={LegalMentions}
-                />
-                <Route
-                    path={`/${t('url.personal-data')}`}
-                    exact
-                    component={PersonalData}
-                />
-                <Route path={`/${t('url.blog')}`} exact component={Blog} />
-                <Route
-                    path={`/${t('url.blog')}/:post`}
-                    exact
-                    component={Blog}
-                />
-                <Route
-                    path={`/${t('url.media')}`}
-                    exact
-                    component={MediaNews}
-                />
+            <IonContent>
+                <Switch>
+                    <Route path="/" exact component={Home} />
+                    <Route
+                        path={`/${t('url.video-call')}/:videoName`}
+                        component={VideoCallPrecheck}
+                    />
+                    <Route
+                        path={`/${t('url.video-call')}`}
+                        component={JoinVideoCall}
+                    />
+                    <Route
+                        path={`/${t('url.legal-mentions')}`}
+                        exact
+                        component={LegalMentions}
+                    />
+                    <Route
+                        path={`/${t('url.personal-data')}`}
+                        exact
+                        component={PersonalData}
+                    />
+                    <Route path={`/${t('url.blog')}`} exact component={Blog} />
+                    <Route
+                        path={`/${t('url.blog')}/:post`}
+                        exact
+                        component={Blog}
+                    />
+                    <Route
+                        path={`/${t('url.media')}`}
+                        exact
+                        component={MediaNews}
+                    />
 
-                <Route
-                    path={`/${t('url.credits')}`}
-                    exact
-                    component={Credits}
-                />
-                <Route
-                    path={`/${t('url.license')}`}
-                    exact
-                    component={License}
-                />
+                    <Route
+                        path={`/${t('url.credits')}`}
+                        exact
+                        component={Credits}
+                    />
+                    <Route
+                        path={`/${t('url.license')}`}
+                        exact
+                        component={License}
+                    />
 
-                <Route path={`/premium-video`} component={PremiumVideoPage} />
-                <Route path={`/welcome`} component={WelcomeCall} />
-                <Route
-                    path={'/permissions-audio-video'}
-                    component={PermissionVideoAudio}
-                />
+                    <Route
+                        path={`/premium-video`}
+                        component={PremiumVideoPage}
+                    />
+                    <Route path={`/welcome`} component={WelcomeCall} />
+                    <Route
+                        path={'/permissions-audio-video'}
+                        component={PermissionVideoAudio}
+                    />
 
-                <ProtectedRoute
-                    path="/admin"
-                    isAuthorized={!isAnonymous}
-                    component={Dashboard}
-                />
-                <Route component={NotFound} />
-            </Switch>
+                    <ProtectedRoute
+                        path="/admin"
+                        isAuthorized={!isAnonymous}
+                        component={Dashboard}
+                    />
+                    <Route component={NotFound} />
+                </Switch>
+            </IonContent>
         </IonRouterOutlet>
     )
 }

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -5,7 +5,6 @@ import Router from './Router'
 import { IonApp, IonHeader } from '@ionic/react'
 import { IonReactRouter } from '@ionic/react-router'
 import AppBar from './AppBar/AppBar'
-import styled from 'styled-components'
 import Snackbar from './Snackbar/Snackbar'
 import { PushNotifications } from './PushNotifications/PushNotifications'
 import LoginModal from '../LoginModal/LoginModal'
@@ -17,10 +16,6 @@ declare global {
         $crisp: any
     }
 }
-
-const StyledRouter = styled.div`
-    margin-top: 1rem;
-`
 
 const App = () => {
     useEffect(() => {
@@ -56,9 +51,7 @@ const App = () => {
                 <IonHeader id="topbar">
                     <AppBar />
                 </IonHeader>
-                <StyledRouter>
-                    <Router />
-                </StyledRouter>
+                <Router />
             </IonReactRouter>
         </IonApp>
     )

--- a/src/components/App/userSelector.ts
+++ b/src/components/App/userSelector.ts
@@ -9,3 +9,9 @@ export const selectUser = createSelector(
 )
 export const selectToken = createSelector(selectUser, ({ token }) => token)
 export const isLoading = ({ user }) => user.isLoading
+
+export const selectIsPremiumUser = createSelector(
+    selectUser,
+    selectToken,
+    (user, token) => token && !user.isAnonymous
+)

--- a/src/pages/Admin/Dashboard.tsx
+++ b/src/pages/Admin/Dashboard.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { IonContent } from '@ionic/react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { Button } from '@material-ui/core'
@@ -24,13 +23,9 @@ export default function Dashboard() {
     }
 
     return (
-        <IonContent style={{ '--background': 'white' }}>
-            <InformationBlock>
-                {t('dashboard.welcome')}
-                <Button onClick={() => startPremiumVideoCall()}>
-                    Start Call
-                </Button>
-            </InformationBlock>
-        </IonContent>
+        <InformationBlock>
+            {t('dashboard.welcome')}
+            <Button onClick={() => startPremiumVideoCall()}>Start Call</Button>
+        </InformationBlock>
     )
 }

--- a/src/pages/Blog/Blog.tsx
+++ b/src/pages/Blog/Blog.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next'
 
 import DefaultLayout from '../../layout/Default/Default'
 import BlogArticle from '../../components/BlogArticle/BlogArticle'
-import { IonContent } from '@ionic/react'
 
 const Blog = () => {
     let { post } = useParams()
@@ -13,43 +12,39 @@ const Blog = () => {
     // returnObjects key is necessary to be able to use objects and arrays
     const blogPosts: [] = t('posts', { returnObjects: true })
     return (
-        <>
-            <IonContent>
-                <DefaultLayout>
-                    {blogPosts
-                        .reverse()
-                        .map(
-                            ({
-                                id,
-                                slug,
-                                title,
-                                date,
-                                authors,
-                                authorsAnd,
-                                content,
-                            }) => {
-                                // either all articles are displayed,
-                                // or the post matching the URL
-                                if (post === slug || !post) {
-                                    return (
-                                        <BlogArticle
-                                            slug={slug}
-                                            title={title}
-                                            pageTitle={post ? title : ''}
-                                            date={date}
-                                            authors={authors}
-                                            authorsAnd={authorsAnd}
-                                            content={content}
-                                            key={id}
-                                        />
-                                    )
-                                }
-                                return ''
-                            }
-                        )}
-                </DefaultLayout>
-            </IonContent>
-        </>
+        <DefaultLayout>
+            {blogPosts
+                .reverse()
+                .map(
+                    ({
+                        id,
+                        slug,
+                        title,
+                        date,
+                        authors,
+                        authorsAnd,
+                        content,
+                    }) => {
+                        // either all articles are displayed,
+                        // or the post matching the URL
+                        if (post === slug || !post) {
+                            return (
+                                <BlogArticle
+                                    slug={slug}
+                                    title={title}
+                                    pageTitle={post ? title : ''}
+                                    date={date}
+                                    authors={authors}
+                                    authorsAnd={authorsAnd}
+                                    content={content}
+                                    key={id}
+                                />
+                            )
+                        }
+                        return ''
+                    }
+                )}
+        </DefaultLayout>
     )
 }
 

--- a/src/pages/Credits/Credits.tsx
+++ b/src/pages/Credits/Credits.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next'
 import DefaultLayout from '../../layout/Default/Default'
 import CreditsStyled from './CreditsStyled'
 import data from './data.json'
-import { IonContent } from '@ionic/react'
 
 const sort = ({ name: aName }, { name: bName }) => {
     const [, aLastname] = aName.split(' ')
@@ -46,13 +45,9 @@ const Credits = () => {
     }
 
     return (
-        <IonContent>
-            <DefaultLayout title={`${t('page-title')} - Instant Visio`}>
-                <CreditsStyled>
-                    {Object.entries(data).map(render)}
-                </CreditsStyled>
-            </DefaultLayout>
-        </IonContent>
+        <DefaultLayout title={`${t('page-title')} - Instant Visio`}>
+            <CreditsStyled>{Object.entries(data).map(render)}</CreditsStyled>
+        </DefaultLayout>
     )
 }
 

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -15,12 +15,10 @@ import {
 } from '../../utils/support'
 import Logo from '../../components/Logo/Logo'
 import useDetectMobileOrTablet from '../../hooks/useDetectMobileOrTablet'
-import { IonContent } from '@ionic/react'
 import * as LocalStorage from '../../services/local-storage'
 import { authInstance } from '../../firebase/firebase'
 import { isAuthEmulatorEnabled } from '../../utils/emulators'
-import { selectToken } from '../../components/App/userSelector'
-import { useSelector, useDispatch } from 'react-redux'
+import { useDispatch } from 'react-redux'
 import { EmulatorLogin } from './EmulatorLogin'
 import { showErrorMessage } from '../../components/App/Snackbar/snackbarActions'
 
@@ -57,7 +55,6 @@ const KnowMoreMobile = styled.p`
 
 export default function Home({ location }) {
     const { t } = useTranslation(['home', 'common', 'premium-video'])
-    const token = useSelector(selectToken)
     const [videoCallId, setVideoCallId] = useState()
     const [error, setError] = useState()
     const isMobile = useDetectMobileOrTablet()
@@ -94,7 +91,7 @@ export default function Home({ location }) {
     }
 
     return (
-        <IonContent>
+        <>
             {isAuthEmulatorEnabled() && (
                 <EmulatorLogin authInstance={authInstance} />
             )}
@@ -171,6 +168,6 @@ export default function Home({ location }) {
                     </MobileContent>
                 </WrapperMobile>
             )}
-        </IonContent>
+        </>
     )
 }

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react'
+import React, { useState, useRef, useEffect } from 'react'
 import styled from 'styled-components'
 import { Link, Route } from 'react-router-dom'
 import { useTranslation, Trans } from 'react-i18next'
@@ -19,7 +19,10 @@ import { IonContent } from '@ionic/react'
 import * as LocalStorage from '../../services/local-storage'
 import { authInstance } from '../../firebase/firebase'
 import { isAuthEmulatorEnabled } from '../../utils/emulators'
+import { selectToken } from '../../components/App/userSelector'
+import { useSelector, useDispatch } from 'react-redux'
 import { EmulatorLogin } from './EmulatorLogin'
+import { showErrorMessage } from '../../components/App/Snackbar/snackbarActions'
 
 const DataMentions = styled.div`
     .cnil {
@@ -52,13 +55,23 @@ const KnowMoreMobile = styled.p`
     text-align: center;
 `
 
-export default function Home() {
-    const { t } = useTranslation(['home', 'common'])
+export default function Home({ location }) {
+    const { t } = useTranslation(['home', 'common', 'premium-video'])
+    const token = useSelector(selectToken)
     const [videoCallId, setVideoCallId] = useState()
     const [error, setError] = useState()
     const isMobile = useDetectMobileOrTablet()
     const formSubmissionMessage: any = useRef(null)
     const [modalShow, setModalShow] = React.useState(false)
+    const dispatch = useDispatch()
+
+    useEffect(() => {
+        if (location.state?.isPremiumVideoPasswordSet === false) {
+            dispatch(
+                showErrorMessage(t('premium-video:errors.missing-password'))
+            )
+        }
+    })
 
     const submit = (values, setSubmitting) => {
         setNewCall(values)

--- a/src/pages/JoinVideoCall/JoinVideoCall.tsx
+++ b/src/pages/JoinVideoCall/JoinVideoCall.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import DefaultLayout from '../../layout/Default/Default'
-import { IonContent } from '@ionic/react'
 import { Redirect, Link } from 'react-router-dom'
 import * as LocalStorage from '../../services/local-storage'
 import styled from 'styled-components'
@@ -26,7 +25,7 @@ const JoinVideoCall = () => {
     }, [setLastVideoCallId])
 
     return (
-        <IonContent>
+        <>
             {lastVideoCallId ? (
                 <Redirect to={`/visio/${lastVideoCallId}`} />
             ) : (
@@ -38,7 +37,7 @@ const JoinVideoCall = () => {
                     </CenteredText>
                 </DefaultLayout>
             )}
-        </IonContent>
+        </>
     )
 }
 

--- a/src/pages/LegalMentions/LegalMentions.tsx
+++ b/src/pages/LegalMentions/LegalMentions.tsx
@@ -4,7 +4,6 @@ import ReactMarkdown from 'react-remarkable'
 import styled from 'styled-components'
 import DefaultLayout from '../../layout/Default/Default'
 import useDetectMobileOrTablet from '../../hooks/useDetectMobileOrTablet'
-import { IonContent } from '@ionic/react'
 const MarkdownContainer = styled.div`
     h2 {
         font-size: ${({ theme }) => theme.font.XL};
@@ -19,17 +18,15 @@ const LegalMentions = () => {
     const isMobile = useDetectMobileOrTablet()
 
     return (
-        <IonContent>
-            <DefaultLayout title={`${t('page-title')} - Instant Visio`}>
-                {isMobile ? (
-                    <MarkdownContainer>
-                        <ReactMarkdown source={t('page-content')} />
-                    </MarkdownContainer>
-                ) : (
+        <DefaultLayout title={`${t('page-title')} - Instant Visio`}>
+            {isMobile ? (
+                <MarkdownContainer>
                     <ReactMarkdown source={t('page-content')} />
-                )}
-            </DefaultLayout>
-        </IonContent>
+                </MarkdownContainer>
+            ) : (
+                <ReactMarkdown source={t('page-content')} />
+            )}
+        </DefaultLayout>
     )
 }
 

--- a/src/pages/License/License.tsx
+++ b/src/pages/License/License.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import DefaultLayout from '../../layout/Default/Default'
-import { IonContent } from '@ionic/react'
 import styled from 'styled-components'
 
 const LicenseStyled = styled.div`
@@ -14,50 +13,47 @@ const License = () => {
     const { t } = useTranslation('license')
 
     return (
-        <IonContent>
-            <DefaultLayout title={`${t('page-title')} - Instant Visio`}>
-                <LicenseStyled>
-                    <p>
-                        You can read Instant Visio application and source code
-                        license{' '}
-                        <a href="https://github.com/Instant-Visio/InstantVisio-WebApp/blob/master/LICENSE">
-                            here
-                        </a>
-                        .
-                    </p>
-                    <p>
-                        Some of the components used to provide premium video
-                        calls features are instead under Apache 2.0 License:
-                        <ul>
-                            <li>
-                                you can have more details in our{' '}
-                                <a href="https://github.com/Instant-Visio/InstantVisio-WebApp/tree/master/NOTICE">
-                                    NOTICE file
-                                </a>
-                            </li>
-                            <li>
-                                you can read the full text of the Apache 2.0
-                                license{' '}
-                                <a href="https://github.com/Instant-Visio/InstantVisio-WebApp/tree/master/src/pages/PremiumVideoCall/LICENSE">
-                                    here
-                                </a>
-                            </li>
-                        </ul>
-                    </p>
-                    <p>
-                        We make use of{' '}
-                        <a href="https://github.com/mui-org/material-ui">
-                            material-ui library
-                        </a>
-                        . You can find its license and copyright notice{' '}
-                        <a href="https://github.com/mui-org/material-ui/blob/next/LICENSE">
-                            here
-                        </a>
-                        .
-                    </p>
-                </LicenseStyled>
-            </DefaultLayout>
-        </IonContent>
+        <DefaultLayout title={`${t('page-title')} - Instant Visio`}>
+            <LicenseStyled>
+                <p>
+                    You can read Instant Visio application and source code
+                    license{' '}
+                    <a href="https://github.com/Instant-Visio/InstantVisio-WebApp/blob/master/LICENSE">
+                        here
+                    </a>
+                    .
+                </p>
+                <p>
+                    Some of the components used to provide premium video calls
+                    features are instead under Apache 2.0 License:
+                    <ul>
+                        <li>
+                            you can have more details in our{' '}
+                            <a href="https://github.com/Instant-Visio/InstantVisio-WebApp/tree/master/NOTICE">
+                                NOTICE file
+                            </a>
+                        </li>
+                        <li>
+                            you can read the full text of the Apache 2.0 license{' '}
+                            <a href="https://github.com/Instant-Visio/InstantVisio-WebApp/tree/master/src/pages/PremiumVideoCall/LICENSE">
+                                here
+                            </a>
+                        </li>
+                    </ul>
+                </p>
+                <p>
+                    We make use of{' '}
+                    <a href="https://github.com/mui-org/material-ui">
+                        material-ui library
+                    </a>
+                    . You can find its license and copyright notice{' '}
+                    <a href="https://github.com/mui-org/material-ui/blob/next/LICENSE">
+                        here
+                    </a>
+                    .
+                </p>
+            </LicenseStyled>
+        </DefaultLayout>
     )
 }
 

--- a/src/pages/NotFound/NotFound.tsx
+++ b/src/pages/NotFound/NotFound.tsx
@@ -2,17 +2,14 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import DefaultLayout from '../../layout/Default/Default'
 import { Link } from 'react-router-dom'
-import { IonContent } from '@ionic/react'
 
 export default function NotFound() {
     const { t } = useTranslation('not-found')
 
     return (
-        <IonContent>
-            <DefaultLayout title={`${t('page-title')} - Instant Visio`}>
-                <h2>{t('page-content')}</h2>
-                <Link to="/">{t('link-back-to-home')}</Link>
-            </DefaultLayout>
-        </IonContent>
+        <DefaultLayout title={`${t('page-title')} - Instant Visio`}>
+            <h2>{t('page-content')}</h2>
+            <Link to="/">{t('link-back-to-home')}</Link>
+        </DefaultLayout>
     )
 }

--- a/src/pages/PersonalData/PersonalData.tsx
+++ b/src/pages/PersonalData/PersonalData.tsx
@@ -3,18 +3,15 @@ import { useTranslation } from 'react-i18next'
 import ReactMarkdown from 'react-remarkable'
 
 import DefaultLayout from '../../layout/Default/Default'
-import { IonContent } from '@ionic/react'
 
 const PersonalData = () => {
     const { t } = useTranslation('personal-data')
 
     return (
         <>
-            <IonContent>
-                <DefaultLayout title={`${t('page-title')} - Instant Visio`}>
-                    <ReactMarkdown source={t('page-content')} />
-                </DefaultLayout>
-            </IonContent>
+            <DefaultLayout title={`${t('page-title')} - Instant Visio`}>
+                <ReactMarkdown source={t('page-content')} />
+            </DefaultLayout>
         </>
     )
 }

--- a/src/pages/PremiumVideoCall/components/MenuBar/MenuBar.tsx
+++ b/src/pages/PremiumVideoCall/components/MenuBar/MenuBar.tsx
@@ -70,6 +70,10 @@ const useStyles = makeStyles((theme: Theme) =>
     })
 )
 
+const formatRoomName = (roomName) => {
+    return roomName.indexOf('#') ? roomName.split('#')[0] : roomName
+}
+
 export default function MenuBar() {
     const classes = useStyles()
     const { isSharingScreen, toggleScreenShare } = useVideoContext()
@@ -78,6 +82,7 @@ export default function MenuBar() {
     const { room } = useVideoContext()
     const roomId = useSelector(selectRoomId)
     const hostName = useSelector(selectHostName)
+    const roomName = formatRoomName(room.name)
 
     return (
         <>
@@ -99,7 +104,7 @@ export default function MenuBar() {
                 <Grid container justify="space-around" alignItems="center">
                     <Hidden smDown>
                         <Grid style={{ flex: 1 }}>
-                            <Typography variant="body1">{room.name}</Typography>
+                            <Typography variant="body1">{roomName}</Typography>
                         </Grid>
                     </Hidden>
                     <Grid item>

--- a/src/pages/PremiumVideoCall/components/PrivateRoute/PrivateRoute.tsx
+++ b/src/pages/PremiumVideoCall/components/PrivateRoute/PrivateRoute.tsx
@@ -25,8 +25,11 @@ export default function PrivateRoute({ children, ...rest }: RouteProps) {
                 ) : (
                     <Redirect
                         to={{
-                            pathname: '/login',
-                            state: { from: location },
+                            pathname: '/',
+                            state: {
+                                from: location,
+                                isPremiumVideoPasswordSet: renderChildren,
+                            },
                         }}
                     />
                 )

--- a/src/pages/PremiumVideoCall/index.tsx
+++ b/src/pages/PremiumVideoCall/index.tsx
@@ -11,13 +11,12 @@ import { MuiThemeProvider } from '@material-ui/core/styles'
 import App from './App'
 import AppStateProvider, { useAppState } from './state'
 import {
-    BrowserRouter as Router,
+    // BrowserRouter as Router,
     Redirect,
-    Route,
     Switch,
 } from 'react-router-dom'
 import ErrorDialog from './components/ErrorDialog/ErrorDialog'
-import LoginPage from './components/LoginPage/LoginPage'
+// import LoginPage from './components/LoginPage/LoginPage'
 import PrivateRoute from './components/PrivateRoute/PrivateRoute'
 import theme from './theme'
 import './types'
@@ -46,22 +45,25 @@ export const PremiumVideoPage = () => {
     return (
         <MuiThemeProvider theme={theme}>
             <CssBaseline />
-            <Router>
-                <AppStateProvider>
-                    <Switch>
+            <AppStateProvider>
+                <Switch>
+                    {/*
+                        Temporarily commented, since we only access PremiumVideo page through a link
+                        containing the room name and password for the moment
+
                         <PrivateRoute exact path="/premium-video">
                             <TwilioVideoApp />
                         </PrivateRoute>
-                        <PrivateRoute path="/premium-video/room/:URLRoomName">
-                            <TwilioVideoApp />
-                        </PrivateRoute>
-                        <Route path="/premium-video/login">
-                            <LoginPage />
-                        </Route>
-                        <Redirect to="/" />
-                    </Switch>
-                </AppStateProvider>
-            </Router>
+                    */}
+                    <PrivateRoute path="/premium-video/room/:URLRoomName">
+                        <TwilioVideoApp />
+                    </PrivateRoute>
+                    {/* <Route path="/premium-video/login">
+                        <LoginPage />
+                    </Route> */}
+                    <Redirect to="/" />
+                </Switch>
+            </AppStateProvider>
         </MuiThemeProvider>
     )
 }

--- a/src/pages/WelcomeCall/WelcomeCall.tsx
+++ b/src/pages/WelcomeCall/WelcomeCall.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { IonContent } from '@ionic/react'
 import Button from '@material-ui/core/Button'
 import styled from 'styled-components'
 import PeopleOutline from '@material-ui/icons/PeopleOutline'
@@ -29,19 +28,17 @@ export default function WelcomeCall() {
     const { t } = useTranslation('welcome-call')
 
     return (
-        <IonContent style={{ '--background': 'white' }}>
-            <InformationBlock>
-                <PeopleOutline fontSize="large" />
-                <h2>
-                    {t('join-visio')} "Test meeting" {t('of')} "Mr. Test"
-                </h2>
-                <h3>{t('verify-it-works')}</h3>
-                <h3>{t('we-take-care')}</h3>
+        <InformationBlock>
+            <PeopleOutline fontSize="large" />
+            <h2>
+                {t('join-visio')} "Test meeting" {t('of')} "Mr. Test"
+            </h2>
+            <h3>{t('verify-it-works')}</h3>
+            <h3>{t('we-take-care')}</h3>
 
-                <Button variant="contained" color="primary">
-                    {t('click-to-start')}
-                </Button>
-            </InformationBlock>
-        </IonContent>
+            <Button variant="contained" color="primary">
+                {t('click-to-start')}
+            </Button>
+        </InformationBlock>
     )
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2,6 +2,7 @@ import { JWTToken } from '../../types/JWT'
 import { JoinRoomResponse } from '../../types/JoinRoomResponse'
 import { NewRoomResponse } from '../../types/NewRoomResponse'
 import { RoomId } from '../../types/Room'
+import axios from 'axios'
 export class Api {
     baseUrl: string | undefined
     jwtToken: string
@@ -40,18 +41,22 @@ export class Api {
     }
 
     async post(apiUrl: string, data: any): Promise<any> {
-        const response = await fetch(`${this.baseUrl}${apiUrl}`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${this.jwtToken}`,
-            },
-            body: data ? JSON.stringify(data) : null,
-        })
-
-        if (response.status !== 200 && response.status !== 204) {
-            throw new Error(response.statusText)
+        const headers = {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this.jwtToken}`,
         }
-        return response.json()
+
+        try {
+            const { data: responseData } = await axios({
+                headers,
+                method: 'post',
+                url: `${this.baseUrl}${apiUrl}`,
+                data,
+            })
+            return responseData
+        } catch (err) {
+            const { error: errorMessage } = err.response.data
+            throw new Error(errorMessage)
+        }
     }
 }


### PR DESCRIPTION
- Wrong routes redirect
- Fix roomName displayed left-bottom in Call screen
- Remove `PremiumVideoCall` page sub-router, only use main router + `Switch`
- redirect to `Home` on `signOut` btn click
- fix top padding: single `IonContent` wrapping the router (remove the others within every page) + adjust general padding in `App.scss`
- Replace `fetch` with `axios`

fix #407, fix #406, fix #399, fix #408, fix #393