### PR TITLE
API: seed route creating user

### DIFF
--- a/functions/src/api/index.ts
+++ b/functions/src/api/index.ts
@@ -9,6 +9,7 @@ import { errorMiddleware } from './middlewares/errorMiddleware'
 import * as cors from 'cors'
 import { isUsingEmulator } from './utils/isUsingEmulator'
 import { sendTestPushNotification } from './v1/invite/sendTestPushNotification'
+import { seeds } from './utils/seeds/seeds'
 
 const app = express()
 
@@ -30,6 +31,7 @@ if (isUsingEmulator()) {
     app.get('/api/v1-tests/notification/push', (req, res) =>
         sendTestPushNotification(req, res)
     )
+    app.get('/api/v1-tests/seeds/', seeds)
 }
 app.use(errorMiddleware)
 

--- a/functions/src/api/utils/seeds/authSeeds.ts
+++ b/functions/src/api/utils/seeds/authSeeds.ts
@@ -1,0 +1,70 @@
+import { UID } from '../../../types/uid'
+import fetch from 'node-fetch'
+import { InternalServerError } from '../../errors/HttpError'
+
+export interface UserSeed {
+    email: string
+    password: string
+}
+
+export const seedAuth = async (
+    url: string,
+    users: UserSeed[]
+): Promise<{
+    premiumUser: UID
+    freeUser: UID
+    overQuotaUser: UID
+}> => {
+    // delete everything first
+    const response = await fetch(
+        `http://${url}/emulator/v1/projects/instantvisio-dev/accounts?key=some-secret-key`,
+        {
+            method: 'DELETE',
+            headers: {
+                Authorization:
+                    'Bearer ya29.AHES6ZRVmB7fkLtd1XTmq6mo0S1wqZZi3-Lh_s-6Uw7p8vtgSwg', // fake from Firebase test, only format useful
+            },
+        }
+    )
+
+    if (!response.ok) {
+        const json = await response.json()
+        console.error(json)
+        throw new InternalServerError('Auth clear failed')
+    }
+
+    try {
+        const userIds: UID[] = []
+        for (const user of users) {
+            const response2 = await fetch(
+                `http://${url}/identitytoolkit.googleapis.com/v1/accounts:signUp?key=some-secret-key`,
+                {
+                    method: 'POST',
+                    headers: {
+                        Accept: 'application/json',
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        email: user.email,
+                        password: user.password,
+                    }),
+                }
+            )
+            const respJson = await response2.json()
+            if (response2.ok) {
+                userIds.push(respJson.localId)
+            } else {
+                throw new InternalServerError('Auth seed failed partially')
+            }
+        }
+        return {
+            premiumUser: userIds[0],
+            freeUser: userIds[1],
+            overQuotaUser: userIds[2],
+        }
+    } catch (error) {
+        console.log(error)
+        throw error
+    }
+    throw new InternalServerError('Auth seed failed partially')
+}

--- a/functions/src/api/utils/seeds/seed.http
+++ b/functions/src/api/utils/seeds/seed.http
@@ -1,0 +1,2 @@
+GET http://localhost:5050/instantvisio-dev/us-central1/api/api/v1-tests/seeds/
+

--- a/functions/src/api/utils/seeds/seedFirestore.ts
+++ b/functions/src/api/utils/seeds/seedFirestore.ts
@@ -1,0 +1,15 @@
+import { db } from '../../../firebase/firebase'
+import { COLLECTIONS } from '../../../db/constants'
+import { UID } from '../../../types/uid'
+
+export const seedFirestore = async (url: string, premiumUserId: UID) => {
+    await db
+        .collection(COLLECTIONS.users)
+        .doc(premiumUserId)
+        .set(
+            {
+                registrationTokens: ['toto'],
+            },
+            { merge: true }
+        )
+}

--- a/functions/src/api/utils/seeds/seeds.ts
+++ b/functions/src/api/utils/seeds/seeds.ts
@@ -1,0 +1,39 @@
+import { Request, Response } from 'express'
+import { wrap } from 'async-middleware'
+import { seedAuth } from './authSeeds'
+import { seedFirestore } from './seedFirestore'
+import { TEST_ACCOUNTS } from '../../../db/constants'
+
+export const seeds = wrap(async (req: Request, res: Response) => {
+    const authEmulatorUrl = 'localhost:9099'
+    const firestoreEmulatorUrl = 'localhost:9099'
+    const {
+        premiumUser,
+        freeUser,
+        overQuotaUser,
+    } = await seedAuth(authEmulatorUrl, [
+        TEST_ACCOUNTS.paidUser,
+        TEST_ACCOUNTS.unpaidUser,
+        TEST_ACCOUNTS.overQuotaUser,
+    ])
+
+    await seedFirestore(firestoreEmulatorUrl, premiumUser)
+
+    res.send({
+        status: 'Done 🥳🍪',
+        data: {
+            premiumUser: {
+                id: premiumUser,
+                ...TEST_ACCOUNTS.paidUser,
+            },
+            freeUser: {
+                id: freeUser,
+                ...TEST_ACCOUNTS.unpaidUser,
+            },
+            overQuotaUser: {
+                id: overQuotaUser,
+                ...TEST_ACCOUNTS.overQuotaUser,
+            },
+        },
+    })
+})


### PR DESCRIPTION
GET `http://localhost:5050/instantvisio-dev/us-central1/api/api/v1-tests/seeds/`

This help local testing using firebase emulators: functions and auth
- create three users (paid, free, overquota)
- onUserCreation from Mattia creation already set the firestore data directly
- return the info
- add "toto" registrationTokens to showcase firestore usage (for future improvement)