### PR TITLE
API: improve getToken and always save hostName

### DIFF
--- a/functions/src/api/errors/HttpError.ts
+++ b/functions/src/api/errors/HttpError.ts
@@ -24,6 +24,12 @@ export class BadRequestError extends HttpError {
     }
 }
 
+export class NoAvailableTokenError extends BadRequestError {
+    constructor() {
+        super('No token available')
+    }
+}
+
 export class UnauthorizedError extends HttpError {
     constructor(message?: string) {
         super(401, message || 'Unauthorized')
@@ -57,6 +63,12 @@ export class GroupReadForbiddenError extends ForbiddenError {
 export class NotFoundError extends HttpError {
     constructor(message?: string) {
         super(404, message || 'Not Found')
+    }
+}
+
+export class UserNotFoundError extends NotFoundError {
+    constructor() {
+        super('User Not Found')
     }
 }
 

--- a/functions/src/api/v1/rooms/createRoom.ts
+++ b/functions/src/api/v1/rooms/createRoom.ts
@@ -138,6 +138,7 @@ export const createRoom = async ({
         sid: twilioRoomResponse.sid,
         twilioRoomId: twilioRoomResponse.twilioRoomId,
         name: name || roomId,
+        hostName,
     })
 
     let processDestinationsResults = {}

--- a/functions/src/callable/getToken.ts
+++ b/functions/src/callable/getToken.ts
@@ -18,7 +18,7 @@ export const getToken = functions.https.onCall(async (data, context) => {
 
     try {
         return {
-            token: await UserDao.getFirstValidToken(context.auth.uid),
+            token: await UserDao.getFirstValidToken(uid),
         }
     } catch (error) {
         if (

--- a/functions/src/db/UserDao.ts
+++ b/functions/src/db/UserDao.ts
@@ -2,7 +2,11 @@ import { UID } from '../types/uid'
 import { JWTToken } from '../types/JWT'
 import { db, documentId, serverTimestamp } from '../firebase/firebase'
 import { COLLECTIONS } from './constants'
-import { BadRequestError, NotFoundError } from '../api/errors/HttpError'
+import {
+    NoAvailableTokenError,
+    NotFoundError,
+    UserNotFoundError,
+} from '../api/errors/HttpError'
 import { User } from '../types/User'
 import admin from 'firebase-admin'
 import FieldValue = admin.firestore.FieldValue
@@ -17,7 +21,7 @@ export class UserDao {
             .get()
 
         if (!userDocumentSnapshot?.exists) {
-            throw new NotFoundError('Resource does not exist')
+            throw new UserNotFoundError()
         }
         return <User>{
             id: userId,
@@ -64,7 +68,7 @@ export class UserDao {
             }
         }
 
-        throw new BadRequestError('No available/valid token')
+        throw new NoAvailableTokenError()
     }
 
     public static async isTokenValid(


### PR DESCRIPTION
- getToken need the onuserCreation firestore hook to be called which may take time and cause timeout on the client side. Fixed by creating a new token if no user or no token yet. 
- always save hostName to a room. 