### PR TITLE
No topbar on video screens

### DIFF
--- a/src/components/App/App.scss
+++ b/src/components/App/App.scss
@@ -64,3 +64,7 @@ ion-content {
 ion-content {
     --ion-background-color: transparent;
 }
+
+.no-topbar-offset {
+    --offset-top: 0 !important;
+}

--- a/src/components/App/AppBar/AppBar.tsx
+++ b/src/components/App/AppBar/AppBar.tsx
@@ -14,6 +14,7 @@ import { selectIsPremiumUser } from '../userSelector'
 import { isMobile, isNative } from '../../../services/platform'
 import { showJoinGroupModal } from '../../JoinGroup/joinGroupModalActions'
 import Logo from '../../Logo/Logo'
+import { selectAppBar } from './redux/appBarSelectors'
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -55,6 +56,7 @@ const AppBar = () => {
     const { t } = useTranslation('common')
     const dispatch = useDispatch()
     const history = useHistory()
+    const { isDisplayed } = useSelector(selectAppBar)
 
     const renderWebOnlyButtons = () => {
         if (!isMobile()) {
@@ -85,26 +87,28 @@ const AppBar = () => {
     }
 
     return (
-        <div className={classes.root}>
-            <WhiteAppBar>
-                <MaterialAppBar color="primary" position="static">
-                    <Toolbar>
-                        <LogoWrapper>
-                            <Logo />
-                        </LogoWrapper>
-                        {isNative() && (
-                            <Button
-                                onClick={openJoinGroupModal}
-                                color="primary">
-                                {t('appBar.joinGroupButton')}
-                            </Button>
-                        )}
-                        {renderWebOnlyButtons()}
-                        <SwipeableTemporaryDrawer />
-                    </Toolbar>
-                </MaterialAppBar>
-            </WhiteAppBar>
-        </div>
+        isDisplayed && (
+            <div className={classes.root}>
+                <WhiteAppBar>
+                    <MaterialAppBar color="primary" position="static">
+                        <Toolbar>
+                            <LogoWrapper>
+                                <Logo />
+                            </LogoWrapper>
+                            {isNative() && (
+                                <Button
+                                    onClick={openJoinGroupModal}
+                                    color="primary">
+                                    {t('appBar.joinGroupButton')}
+                                </Button>
+                            )}
+                            {renderWebOnlyButtons()}
+                            <SwipeableTemporaryDrawer />
+                        </Toolbar>
+                    </MaterialAppBar>
+                </WhiteAppBar>
+            </div>
+        )
     )
 }
 

--- a/src/components/App/AppBar/redux/appBarActionTypes.ts
+++ b/src/components/App/AppBar/redux/appBarActionTypes.ts
@@ -1,0 +1,12 @@
+export const SHOW_APP_BAR = 'SHOW_APP_BAR'
+export const HIDE_APP_BAR = 'HIDE_APP_BAR'
+
+interface ShowAppBarAction {
+    type: typeof SHOW_APP_BAR
+}
+
+interface HideAppBarAction {
+    type: typeof HIDE_APP_BAR
+}
+
+export type AppBarActionTypes = HideAppBarAction | ShowAppBarAction

--- a/src/components/App/AppBar/redux/appBarActions.ts
+++ b/src/components/App/AppBar/redux/appBarActions.ts
@@ -1,11 +1,11 @@
 import { AppBarActionTypes } from './appBarActionTypes'
 import { SHOW_APP_BAR, HIDE_APP_BAR } from './appBarActionTypes'
 
-export const show = (): AppBarActionTypes => ({
+const show = (): AppBarActionTypes => ({
     type: SHOW_APP_BAR,
 })
 
-export const hide = (): AppBarActionTypes => ({
+const hide = (): AppBarActionTypes => ({
     type: HIDE_APP_BAR,
 })
 

--- a/src/components/App/AppBar/redux/appBarActions.ts
+++ b/src/components/App/AppBar/redux/appBarActions.ts
@@ -1,0 +1,31 @@
+import { AppBarActionTypes } from './appBarActionTypes'
+import { SHOW_APP_BAR, HIDE_APP_BAR } from './appBarActionTypes'
+
+export const show = (): AppBarActionTypes => ({
+    type: SHOW_APP_BAR,
+})
+
+export const hide = (): AppBarActionTypes => ({
+    type: HIDE_APP_BAR,
+})
+
+const setIsTopbarOffsetDisplayed = (isDisplayed: boolean) => {
+    const noTopBarOffsetClass = 'no-topbar-offset'
+    const classList = document.getElementsByTagName('ion-content')[0].classList
+
+    if (isDisplayed) {
+        classList.remove(noTopBarOffsetClass)
+    } else {
+        classList.add(noTopBarOffsetClass)
+    }
+}
+
+export const showAppBar = () => (dispatch) => {
+    setIsTopbarOffsetDisplayed(true)
+    dispatch(show())
+}
+
+export const hideAppBar = () => (dispatch) => {
+    setIsTopbarOffsetDisplayed(false)
+    dispatch(hide())
+}

--- a/src/components/App/AppBar/redux/appBarReducer.ts
+++ b/src/components/App/AppBar/redux/appBarReducer.ts
@@ -1,0 +1,20 @@
+import produce, { Draft } from 'immer'
+import { HIDE_APP_BAR, SHOW_APP_BAR } from './appBarActionTypes'
+import { AppBarState } from './appBarSelectors'
+
+const initialState = {
+    isDisplayed: true,
+}
+
+export const appBarReducer = produce(
+    (draft: Draft<AppBarState>, { type, payload }) => {
+        switch (type) {
+            case HIDE_APP_BAR:
+                draft.isDisplayed = false
+                break
+            case SHOW_APP_BAR:
+                return initialState
+        }
+    },
+    initialState
+)

--- a/src/components/App/AppBar/redux/appBarSelectors.ts
+++ b/src/components/App/AppBar/redux/appBarSelectors.ts
@@ -1,0 +1,13 @@
+import { AppState } from '../../../../reducers/rootReducer'
+import { createSelector } from 'reselect'
+
+export interface DisplayState {
+    isDisplayed: boolean
+}
+
+export interface AppBarState extends DisplayState {}
+
+export const selectAppBar = createSelector(
+    (state: AppState) => state.appBar,
+    (appBar: AppBarState) => appBar
+)

--- a/src/pages/PremiumVideoCall/App.tsx
+++ b/src/pages/PremiumVideoCall/App.tsx
@@ -3,7 +3,7 @@
  * Mattia Primavera <sconqua@gmail.com>
  */
 
-import React from 'react'
+import React, { useEffect } from 'react'
 import { styled, Theme } from '@material-ui/core/styles'
 
 import MenuBar from './components/MenuBar/MenuBar'
@@ -14,6 +14,11 @@ import Room from './components/Room/Room'
 
 import useHeight from './hooks/useHeight/useHeight'
 import useRoomState from './hooks/useRoomState/useRoomState'
+import { useDispatch } from 'react-redux'
+import {
+    showAppBar,
+    hideAppBar,
+} from '../../components/App/AppBar/redux/appBarActions'
 
 const Container = styled('div')({
     display: 'grid',
@@ -33,6 +38,15 @@ const Main = styled('main')(({ theme }: { theme: Theme }) => ({
 
 export default function App() {
     const roomState = useRoomState()
+    const dispatch = useDispatch()
+
+    useEffect(() => {
+        if (roomState === 'disconnected') {
+            dispatch(showAppBar())
+        } else {
+            dispatch(hideAppBar())
+        }
+    }, [roomState, dispatch])
 
     // Here we would like the height of the main container to be the height of the viewport.
     // On some mobile browsers, 'height: 100vh' sets the height equal to that of the screen,

--- a/src/reducers/rootReducer.ts
+++ b/src/reducers/rootReducer.ts
@@ -13,6 +13,8 @@ import { JoinGroupModalState } from '../components/JoinGroup/joinGroupModalSelec
 import { joinGroupModalReducer } from '../components/JoinGroup/joinGroupModalReducer'
 import { RoomsState } from '../pages/AdminDashboard/roomsSelector'
 import { roomsReducer } from '../pages/AdminDashboard/roomsReducer'
+import { AppBarState } from '../components/App/AppBar/redux/appBarSelectors'
+import { appBarReducer } from '../components/App/AppBar/redux/appBarReducer'
 
 export interface AppState {
     user: UserState
@@ -23,6 +25,7 @@ export interface AppState {
     modal: ModalState
     joinGroupModal: JoinGroupModalState
     rooms: RoomsState
+    appBar: AppBarState
 }
 
 const rootReducer = combineReducers({
@@ -34,6 +37,7 @@ const rootReducer = combineReducers({
     modal: modalReducer,
     joinGroupModal: joinGroupModalReducer,
     rooms: roomsReducer,
+    appBar: appBarReducer,
 })
 
 export default rootReducer


### PR DESCRIPTION
- fix #550 Call screen should not be scrollable 
- fix #430 No Topbar on video screens
- place `redux` component related files into a `${componentName}/redux` directory
- define a `DisplayState` interface to extend from