### PR TITLE
improve rating UI on low res computer #532

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -10,19 +10,25 @@ import Typography from '@material-ui/core/Typography'
 
 const useStyles = makeStyles((theme) => ({
     root: {
-        maxWidth: 1500,
+        maxWidth: '100%',
         [theme.breakpoints.down('md')]: {
-            maxWidth: 300,
+            maxWidth: '90%',
         },
     },
     title: {
         fontSize: 40,
+        [theme.breakpoints.down('md')]: {
+            fontSize: 28,
+        },
         textAlign: 'center',
         fontWeight: 'bold',
         color: '#30404f',
     },
     pos: {
         fontSize: 35,
+        [theme.breakpoints.down('md')]: {
+            fontSize: 17,
+        },
         textAlign: 'center',
         fontWeight: 'bold',
         color: '#30404f',
@@ -36,6 +42,9 @@ const useStyles = makeStyles((theme) => ({
     button: {
         margin: theme.spacing(1),
         fontSize: 20,
+        [theme.breakpoints.down('md')]: {
+            fontSize: 10,
+        }
     },
 }))
 

--- a/src/pages/VideoCall/VideoCallFrame.tsx
+++ b/src/pages/VideoCall/VideoCallFrame.tsx
@@ -13,11 +13,18 @@ import { addCallRating } from '../../actions/addCallRating'
 
 const useStyles = makeStyles((theme) => ({
     root: {
-        maxWidth: 1500,
-        [theme.breakpoints.down('md')]: {
-            maxWidth: 300,
-        },
+        maxWidth: '100%'
     },
+    help: {
+        fontSize: 20,
+        [theme.breakpoints.down('md')]: {
+            fontSize: 12,
+            marginLeft:30,
+            marginRight:30
+        },
+        textAlign: 'center',
+        color: 'white'
+    }
 }))
 
 const StyledRating = withStyles({
@@ -28,7 +35,6 @@ const StyledRating = withStyles({
       color: '#724BDD',
     },
   })(Rating);
-
 
 const VideoCallFrame = ({
     participantsNumber,
@@ -82,6 +88,10 @@ const VideoCallFrame = ({
 
             {hasLeft && (
                 <div>
+                    <Grid
+                        container
+                        justify="center"
+                        alignItems="center">
                     <Card 
                         title={t('leave-title-card')} 
                         messageOne={t('leave-messageOne-card')} 
@@ -93,14 +103,13 @@ const VideoCallFrame = ({
                         container
                         justify="center"
                         alignItems="center"
-                        className={classes.root}>
+                        >
                         <Typography
-                            style={{ textAlign: 'center', marginTop: 20 }}
+                            className={classes.help}
                             variant="h5"
                             component="h6">
                             {t('leave-help-us-message')}
                         </Typography>
-                    </Grid>
                     <Grid container justify="center" alignItems="center">
                         <StyledRating
                             name="instantvisio-feedback"
@@ -109,6 +118,8 @@ const VideoCallFrame = ({
                             onChange={onChange}
                         />
                     </Grid>
+                </Grid>
+            </Grid>
                 </div>
             )}
         </IframeContainer>


### PR DESCRIPTION
<img width="599" alt="Capture d’écran 2021-01-07 à 03 02 27" src="https://user-images.githubusercontent.com/27282579/103842719-d394e880-5096-11eb-9a70-eda4878538c7.png">
<img width="521" alt="Capture d’écran 2021-01-07 à 03 03 01" src="https://user-images.githubusercontent.com/27282579/103842724-d4c61580-5096-11eb-94ed-e2c82b7a095c.png">
<img width="559" alt="Capture d’écran 2021-01-07 à 03 03 22" src="https://user-images.githubusercontent.com/27282579/103842733-d68fd900-5096-11eb-92f6-54bd3865f801.png">
<img width="368" alt="Capture d’écran 2021-01-07 à 03 03 40" src="https://user-images.githubusercontent.com/27282579/103842737-d8599c80-5096-11eb-84b8-0666eb29046e.png">
<img width="398" alt="Capture d’écran 2021-01-07 à 03 04 01" src="https://user-images.githubusercontent.com/27282579/103842742-da236000-5096-11eb-9e32-84bf048ed7de.png">
<img width="446" alt="Capture d’écran 2021-01-07 à 03 04 19" src="https://user-images.githubusercontent.com/27282579/103842744-dbed2380-5096-11eb-92d6-2091b5f60c3c.png">
<img width="425" alt="Capture d’écran 2021-01-07 à 03 04 35" src="https://user-images.githubusercontent.com/27282579/103842749-ddb6e700-5096-11eb-8468-99393eabf773.png">
<img width="357" alt="Capture d’écran 2021-01-07 à 03 04 58" src="https://user-images.githubusercontent.com/27282579/103842753-df80aa80-5096-11eb-842c-a22a9cf8ebd9.png">
<img width="412" alt="Capture d’écran 2021-01-07 à 03 05 13" src="https://user-images.githubusercontent.com/27282579/103842760-e0b1d780-5096-11eb-80b2-6a6c43e775ec.png">
<img width="454" alt="Capture d’écran 2021-01-07 à 03 05 29" src="https://user-images.githubusercontent.com/27282579/103842761-e27b9b00-5096-11eb-9826-61f00f2e1d47.png">
<img width="387" alt="Capture d’écran 2021-01-07 à 03 05 48" src="https://user-images.githubusercontent.com/27282579/103842765-e4455e80-5096-11eb-9286-445c93871a14.png">
<img width="400" alt="Capture d’écran 2021-01-07 à 03 06 03" src="https://user-images.githubusercontent.com/27282579/103842768-e60f2200-5096-11eb-8547-cf360eba7c08.png">
<img width="1255" alt="Capture d’écran 2021-01-07 à 03 06 25" src="https://user-images.githubusercontent.com/27282579/103842774-e7404f00-5096-11eb-8e8d-2bc28592041e.png">
<img width="1680" alt="Capture d’écran 2021-01-07 à 03 06 47" src="https://user-images.githubusercontent.com/27282579/103842779-e9a2a900-5096-11eb-8b53-b8a79c5791ac.png">
