### PR TITLE
API: add reminders edit on editRoom, fix createGroup and add startAt on push data

### DIFF
--- a/functions/src/api/v1/group/createGroup.ts
+++ b/functions/src/api/v1/group/createGroup.ts
@@ -68,6 +68,12 @@ export const createGroup = wrap(async (req: Request, res: Response) => {
     const password = req.body.password
     const members = JSONParse(req.body.members || '[]')
 
+    // add the owner to the members
+    members.push({
+        id: userId,
+        name: 'Owner',
+    })
+
     if (!password) {
         throw new BadRequestError('Password is required')
     }

--- a/functions/src/api/v1/rooms/createRoom.ts
+++ b/functions/src/api/v1/rooms/createRoom.ts
@@ -13,9 +13,9 @@ import {
     inviteParticipant,
     InviteParticipantsResponse,
 } from '../invite/inviteParticipants'
-import { JSONParse } from '../utils/JSONParse'
 import { parseDestinations } from '../utils/parseDestinations'
 import { ROOM_MAX_DURATION_MILLISECONDS } from '../../../constants'
+import { parseSendsAt } from './parseSendsAt'
 
 /**
  * @swagger
@@ -205,10 +205,6 @@ type ProcessDestinationsResponse =
     | {
           reminderIds: ReminderId[]
       }
-
-const parseSendsAt = (sendsAt: string | Array<string>): string[] => {
-    return Array.isArray(sendsAt) ? sendsAt : JSONParse(sendsAt)
-}
 
 const isRoomStartingBeforeMaxDuration = (startAt: Timestamp) => {
     return startAt.toMillis() < Date.now() + ROOM_MAX_DURATION_MILLISECONDS

--- a/functions/src/api/v1/rooms/editRoom.ts
+++ b/functions/src/api/v1/rooms/editRoom.ts
@@ -5,6 +5,9 @@ import { Timestamp } from '../../../firebase/firebase'
 import { RoomDao, RoomEditData } from '../../../db/RoomDao'
 import { BadRequestError } from '../../errors/HttpError'
 import { parseDestinations } from '../utils/parseDestinations'
+import { parseSendsAt } from './parseSendsAt'
+import { ReminderDao } from '../../../db/ReminderDao'
+import { RoomId } from '../../../types/Room'
 
 /**
  * @swagger
@@ -25,6 +28,15 @@ import { parseDestinations } from '../utils/parseDestinations'
  *       - $ref: '#/components/parameters/room/destinations'
  *       - $ref: '#/components/parameters/room/hostName'
  *       - $ref: '#/components/parameters/room/timezone'
+ *       - name: sendsAt
+ *         description: (optional) An array of UTC timestamp(s) in seconds at which the reminder(s) are scheduled to be sent. If supplied, this will replace ALL room reminders if adding those reminders first is successful.
+ *         in: x-www-form-urlencoded
+ *         required: false
+ *         type: string
+ *         examples:
+ *            mixed:
+ *                summary: Multiple sendAt dates
+ *                value: '[1708118298, 1808118298]'
  *     responses:
  *       204:
  *         description: Room edited with success
@@ -72,5 +84,26 @@ export const editRoom = wrap(async (req: Request, res: Response) => {
 
     await RoomDao.update(dataToEdit)
 
+    if (req.body.sendsAt) {
+        await updateReminders(roomId, req.body.sendsAt)
+    }
+
     res.send()
 })
+
+const updateReminders = async (roomId: RoomId, sendsAt: string) => {
+    const sendsAtValues = parseSendsAt(sendsAt)
+    if (sendsAtValues.length > 0) {
+        const oldReminders = await ReminderDao.listByRoomId(roomId)
+
+        for (const sendAt of sendsAtValues) {
+            const sendAtMillis = parseInt(sendAt) * 1000
+            const sendAtTimestamp = Timestamp.fromMillis(sendAtMillis)
+            await ReminderDao.add(roomId, sendAtTimestamp)
+        }
+
+        for (const reminder of oldReminders) {
+            await ReminderDao.delete(reminder.id)
+        }
+    }
+}

--- a/functions/src/api/v1/rooms/parseSendsAt.ts
+++ b/functions/src/api/v1/rooms/parseSendsAt.ts
@@ -1,0 +1,5 @@
+import { JSONParse } from '../utils/JSONParse'
+
+export const parseSendsAt = (sendsAt: string | Array<string>): string[] => {
+    return Array.isArray(sendsAt) ? sendsAt : JSONParse(sendsAt)
+}

--- a/functions/src/api/v1/rooms/service/makeParticipantNameUnique.ts
+++ b/functions/src/api/v1/rooms/service/makeParticipantNameUnique.ts
@@ -1,6 +1,5 @@
 import { twilioClient } from './twilioClient'
 import { RoomId } from '../../../../types/Room'
-import { TwilioConstants } from './TwilioConstants'
 import { LOTR_NAMES } from '../../utils/LOTR_NAMES'
 
 export const makeParticipantNameUnique = async (
@@ -17,9 +16,7 @@ export const makeParticipantNameUnique = async (
 
     const connectedParticipantNames = participants.reduce(
         (acc: string[], participant) => {
-            if (participant.status === TwilioConstants.STATUS_CONNECTED) {
-                acc.push(participant.identity)
-            }
+            acc.push(participant.identity)
 
             return acc
         },

--- a/functions/src/db/ReminderDao.ts
+++ b/functions/src/db/ReminderDao.ts
@@ -15,18 +15,9 @@ export class ReminderDao {
             .get()
 
         return snapshot.docs.map((doc) => {
-            const {
-                destinations,
-                hostName,
-                sendAt,
-                isSent,
-                createdAt,
-                updatedAt,
-            } = doc.data()
+            const { sendAt, isSent, createdAt, updatedAt } = doc.data()
             return {
                 id: doc.id,
-                destinations,
-                hostName,
                 roomId,
                 sendAt: sendAt.seconds,
                 isSent,

--- a/functions/src/notifications/sendNotifications.ts
+++ b/functions/src/notifications/sendNotifications.ts
@@ -171,6 +171,7 @@ const processPushDestinations = async (
                     password: room.password,
                     timezone: content.timezone,
                     roomUrl: content.roomUrl,
+                    startAt: room.startAt.toMillis() / 1000,
                 },
             }
             if (content.timezone) {


### PR DESCRIPTION
- reminders can be edited on editRoom endpoint if sendsAt is supplied
- owner of a group is automatically added to the group member (so he can see those groups upon getting all his groups)
- startAt field to push data to we can adjust the notification sounds if the room does not start now
- check for unique participant name on all the room existing user no matter if they are there or not (issue happen during real testing)

Fix https://github.com/Instant-Visio/InstantVisio-WebApp/issues/580
