### PR TITLE
API: Add getting rooms by user groups

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -15,6 +15,88 @@
             ]
         },
         {
+            "collectionGroup": "reminders",
+            "queryScope": "COLLECTION",
+            "fields": [
+                {
+                    "fieldPath": "isSent",
+                    "order": "ASCENDING"
+                },
+                {
+                    "fieldPath": "sentAt",
+                    "order": "ASCENDING"
+                }
+            ]
+        },
+        {
+            "collectionGroup": "rooms",
+            "queryScope": "COLLECTION",
+            "fields": [
+                {
+                    "fieldPath": "groupsIds",
+                    "arrayConfig": "CONTAINS"
+                },
+                {
+                    "fieldPath": "createdAt",
+                    "order": "DESCENDING"
+                }
+            ]
+        },
+        {
+            "collectionGroup": "rooms",
+            "queryScope": "COLLECTION",
+            "fields": [
+                {
+                    "fieldPath": "groupsIds",
+                    "arrayConfig": "CONTAINS"
+                },
+                {
+                    "fieldPath": "startAt",
+                    "order": "ASCENDING"
+                },
+                {
+                    "fieldPath": "createdAt",
+                    "order": "DESCENDING"
+                }
+            ]
+        },
+        {
+            "collectionGroup": "rooms",
+            "queryScope": "COLLECTION",
+            "fields": [
+                {
+                    "fieldPath": "groupsIds",
+                    "arrayConfig": "CONTAINS"
+                },
+                {
+                    "fieldPath": "status",
+                    "order": "ASCENDING"
+                },
+                {
+                    "fieldPath": "createdAt",
+                    "order": "DESCENDING"
+                }
+            ]
+        },
+        {
+            "collectionGroup": "rooms",
+            "queryScope": "COLLECTION",
+            "fields": [
+                {
+                    "fieldPath": "status",
+                    "order": "ASCENDING"
+                },
+                {
+                    "fieldPath": "uid",
+                    "order": "ASCENDING"
+                },
+                {
+                    "fieldPath": "createdAt",
+                    "order": "DESCENDING"
+                }
+            ]
+        },
+        {
             "collectionGroup": "rooms",
             "queryScope": "COLLECTION",
             "fields": [

--- a/functions/src/api/errors/HttpError.ts
+++ b/functions/src/api/errors/HttpError.ts
@@ -65,6 +65,12 @@ export class GroupReadForbiddenError extends ForbiddenError {
     }
 }
 
+export class GroupJoinLimitReachedError extends ForbiddenError {
+    constructor() {
+        super('Unable to join more than 10 groups')
+    }
+}
+
 export class NotFoundError extends HttpError {
     constructor(message?: string) {
         super(404, message || 'Not Found')

--- a/functions/src/api/v1/rooms/editRoom.ts
+++ b/functions/src/api/v1/rooms/editRoom.ts
@@ -74,6 +74,18 @@ export const editRoom = wrap(async (req: Request, res: Response) => {
             throw new BadRequestError('Missing hostName in request body')
         }
         dataToEdit.destinations = parseDestinations(req.body.destinations)
+        const groupsIds: string[] = dataToEdit.destinations.reduce(
+            (acc: string[], invit) => {
+                if (invit.groupId) {
+                    acc.push(invit.groupId)
+                }
+                return acc
+            },
+            []
+        )
+        if (groupsIds.length) {
+            dataToEdit.groupsIds = groupsIds
+        }
     }
     if (req.body.hostName) {
         dataToEdit.hostName = req.body.hostName

--- a/functions/src/api/v1/rooms/getRooms.ts
+++ b/functions/src/api/v1/rooms/getRooms.ts
@@ -1,12 +1,14 @@
 import { Request, Response } from 'express'
 import { RoomDao } from '../../../db/RoomDao'
 import { wrap } from 'async-middleware'
+import { RoomStatus } from '../../../types/Room'
+import { GroupDao } from '../../../db/GroupDao'
 
 /**
  * @swagger
  * /v1/rooms/:
  *   get:
- *     description: List created rooms.
+ *     description: List rooms linked to the current user id, either created room by the user, and rooms available to the user (in groups for example).
  *     tags: ['rooms']
  *     produces:
  *       - application/json
@@ -14,11 +16,24 @@ import { wrap } from 'async-middleware'
  *       - in: query
  *         name: startingAfter
  *         description: (optional) Only return the room starting after the given timestamp in seconds (startAt)
+ *         required: false
  *         schema:
  *           type: integer
+ *       - in: query
+ *         name: status
+ *         description: (optional) the current room status. <br/>"created"= new or ongoing room, <br/>"ended"= room without participant for 5 minutes
+ *         required: false
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: includeGroups
+ *         description: (optional) include rooms linked to the groups the user is a member of
+ *         required: false
+ *         schema:
+ *           type: string
  *     responses:
  *       200:
- *         description: All the rooms linked to this token
+ *         description: Rooms list
  *         content:
  *           application/json:
  *             example: [{
@@ -45,12 +60,30 @@ import { wrap } from 'async-middleware'
  */
 export const getRooms = wrap(async (req: Request, res: Response) => {
     const uid = res.locals.uid
-    const startingAfter = <string>req.query.startingAfter
+    const startingAfterQuery = <string>req.query.startingAfter
+    const statusQuery = <RoomStatus>req.query.status
+    const includeGroups = <string>req.query.includeGroups
 
-    const rooms = await RoomDao.listByUserId(
+    const startingAfter = startingAfterQuery ? parseInt(startingAfterQuery) : 0
+    const status = statusQuery ? statusQuery : undefined
+
+    const createdByUserRooms = await RoomDao.listByUserId(
         uid,
-        startingAfter ? parseInt(startingAfter) : 0
+        startingAfter,
+        status
     )
 
-    res.send(rooms)
+    if (includeGroups === 'true') {
+        const groups = await GroupDao.listByUserId(uid)
+        const groupsIds = groups.map((group) => group.id).splice(0, 10)
+        const groupRooms = await RoomDao.listByGroupsIds(
+            groupsIds,
+            startingAfter,
+            status
+        )
+        res.send([...createdByUserRooms, ...groupRooms])
+        return
+    }
+
+    res.send(createdByUserRooms)
 })


### PR DESCRIPTION
upgate `get rooms`: 
- add includeGroups boolean in query
- add status string (created, ended) in query
- updated indexes
- store groupsIds in rooms to be queried for the group listing

To display ongoing call for a user, we should query `v1/rooms?includeGroups=true&status=created` 