### PR TITLE
Show onGoingCalls on mobile

### DIFF
--- a/public/locales/en/home.json
+++ b/public/locales/en/home.json
@@ -16,5 +16,9 @@
             "mandatory": "Fields marked by an asterisk are mandatory.",
             "management": "The person in charge of data, Stéphane Luçon, processes the collected information before sending the SMS or e-mail to your contact. Your information will be deleted one day after it has been sent. To learn more about data privacy or to exercise your rights regarding your personal data, please see section <1>Personal data</1>."
         }
+    },
+    "ongoing-calls": {
+        "join": "Join",
+        "calls": "Ongoing calls"
     }
 }

--- a/public/locales/fr/home.json
+++ b/public/locales/fr/home.json
@@ -16,5 +16,9 @@
             "mandatory": "Les champs marqués d'un astérisque sont obligatoires.",
             "management": "Le responsable de traitement, Stéphane Luçon, s'assure du traitement des données recueillies pour effectuer l'envoi du SMS ou de l'e-mail au correspondant. Suite à l'envoi, ces données sont effacées au bout d'un jour. Pour en savoir plus sur la gestion des données personnelles et pour exercer vos droits, veuillez vous reporter à la page <1>Données personnelles</1>."
         }
+    },
+    "ongoing-calls": {
+        "join": "Rejoindre",
+        "calls": "Appels en cours"
     }
 }

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -21,6 +21,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { EmulatorLogin } from './EmulatorLogin'
 import { showErrorMessage } from '../../components/App/Snackbar/snackbarActions'
 import { selectUser } from '../../components/App/userSelector'
+import { PendingCalls } from './PendingCalls/PendingCalls'
 
 const DataMentions = styled.div`
     .cnil {
@@ -140,6 +141,7 @@ export default function Home({ location }) {
                         <DescriptionMobile>
                             {t('information.form-submit')}
                         </DescriptionMobile>
+                        <PendingCalls />
                         <FormMobile onSubmit={submit} error={error} />
                         <div ref={formSubmissionMessage}>
                             {videoCallId && (

--- a/src/pages/Home/PendingCalls/PendingCalls.tsx
+++ b/src/pages/Home/PendingCalls/PendingCalls.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react'
+import { Button, Grid, Typography } from '@material-ui/core'
+import styled from 'styled-components'
+import { Api } from '../../../services/api'
+import { openPremiumVideoCall } from '../../../services/safari-view-controller'
+import { selectToken } from '../../../components/App/userSelector'
+import { useSelector } from 'react-redux'
+
+const StyledPendingCalls = styled.div`
+    font-size: ${({ theme }) => theme.font.S};
+`
+
+const StyledCard = styled.div`
+    background: ${({ theme }) => theme.color.white};
+    color: ${({ theme }) => theme.color.grey};
+    padding: ${({ theme }) => `${theme.spacing.XXL} ${theme.spacing.XL}`};
+    border-radius: 0.5rem;
+
+    & [role='tab'] {
+        outline: none;
+    }
+`
+
+export const PendingCalls = () => {
+    const [onGoingCalls, setOnGoingCalls] = useState<any>([])
+    const token = useSelector(selectToken)
+    const api = new Api(token)
+
+    useEffect(() => {
+        api.getOngoingCalls().then((onGoingCalls) =>
+            setOnGoingCalls(onGoingCalls)
+        )
+    }, [api])
+
+    const getGroupName = (currentCall) => {
+        const { destinations } = currentCall
+        const [destination] = destinations.filter(
+            (destination) => destination.groupId
+        )
+        if (destination) {
+            return `(${destination.groupId})`
+        } else return ''
+    }
+
+    const formatCallStartsAt = (callDate) => {
+        return new Date(callDate).toLocaleString()
+    }
+
+    return onGoingCalls.length ? (
+        <StyledCard style={{ marginBottom: '0.5rem' }}>
+            <Grid container spacing={1} direction="column">
+                <Grid item style={{ fontWeight: 'bold' }}>
+                    <Typography variant="body1">Appels en cours</Typography>
+                </Grid>
+                <StyledPendingCalls style={{ width: '100%' }}>
+                    <Grid item container alignItems="center">
+                        {onGoingCalls.map((currentCall) => {
+                            return (
+                                <>
+                                    <Grid item xs={8}>
+                                        <p>
+                                            {currentCall.name}{' '}
+                                            {getGroupName(currentCall)}{' '}
+                                            {formatCallStartsAt(
+                                                currentCall.startAt * 1000
+                                            )}
+                                        </p>
+                                    </Grid>
+                                    <Grid item xs={4}>
+                                        <Button
+                                            variant="outlined"
+                                            size="small"
+                                            onClick={() =>
+                                                openPremiumVideoCall(
+                                                    currentCall.roomUrl
+                                                )
+                                            }>
+                                            Rejoindre
+                                        </Button>
+                                    </Grid>
+                                </>
+                            )
+                        })}
+                    </Grid>
+                </StyledPendingCalls>
+            </Grid>
+        </StyledCard>
+    ) : (
+        <></>
+    )
+}

--- a/src/pages/Home/PendingCalls/PendingCalls.tsx
+++ b/src/pages/Home/PendingCalls/PendingCalls.tsx
@@ -5,6 +5,7 @@ import { Api } from '../../../services/api'
 import { openPremiumVideoCall } from '../../../services/safari-view-controller'
 import { selectToken } from '../../../components/App/userSelector'
 import { useSelector } from 'react-redux'
+import { useTranslation } from 'react-i18next'
 
 const StyledPendingCalls = styled.div`
     font-size: ${({ theme }) => theme.font.S};
@@ -22,15 +23,18 @@ const StyledCard = styled.div`
 `
 
 export const PendingCalls = () => {
+    const { t } = useTranslation('home')
     const [onGoingCalls, setOnGoingCalls] = useState<any>([])
     const token = useSelector(selectToken)
-    const api = new Api(token)
 
     useEffect(() => {
-        api.getOngoingCalls().then((onGoingCalls) =>
-            setOnGoingCalls(onGoingCalls)
-        )
-    }, [api])
+        if (token) {
+            const api = new Api(token)
+            api.getOngoingCalls().then((onGoingCalls) =>
+                setOnGoingCalls(onGoingCalls)
+            )
+        }
+    }, [token])
 
     const getGroupName = (currentCall) => {
         const { destinations } = currentCall
@@ -50,7 +54,9 @@ export const PendingCalls = () => {
         <StyledCard style={{ marginBottom: '0.5rem' }}>
             <Grid container spacing={1} direction="column">
                 <Grid item style={{ fontWeight: 'bold' }}>
-                    <Typography variant="body1">Appels en cours</Typography>
+                    <Typography variant="body1">
+                        {t('home:ongoing-calls.calls')}
+                    </Typography>
                 </Grid>
                 <StyledPendingCalls style={{ width: '100%' }}>
                     <Grid item container alignItems="center">
@@ -75,7 +81,7 @@ export const PendingCalls = () => {
                                                     currentCall.roomUrl
                                                 )
                                             }>
-                                            Rejoindre
+                                            {t('home:ongoing-calls.join')}
                                         </Button>
                                     </Grid>
                                 </>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -115,6 +115,10 @@ export class Api {
         )
     }
 
+    async getOngoingCalls(): Promise<any> {
+        return this.apiClient.get('/rooms?includeGroups=true&status=created')
+    }
+
     async getUserDetails(userId): Promise<any> {
         return this.apiClient.get(`/users/${userId}`)
     }


### PR DESCRIPTION
Add a block to display the list of OnGoingCalls on mobile home page only.
Every item of the list contains a Join button for joining the call.